### PR TITLE
Add Server Side Sorting

### DIFF
--- a/helpers/scopify.js
+++ b/helpers/scopify.js
@@ -2,6 +2,13 @@ export default function scopify(query, ...params) {
   const scopes = [{
     method: ['paginate', query.perPage, query.page],
   }];
+  if (query.orderBy) {
+    scopes.push({
+      method: ['orderBy', query.orderBy, query.direction],
+    });
+    delete query.orderBy;
+    delete query.direction;
+  }
   params.forEach((param) => {
     if (typeof query[param] !== 'undefined') {
       scopes.push({

--- a/helpers/sorting.js
+++ b/helpers/sorting.js
@@ -1,0 +1,11 @@
+export default function (field, direction, whitelist) {
+  // Only allow sorting by whitelisted fields
+  if (!whitelist.includes(field)) {
+    return {};
+  }
+
+  return {
+    // Sequelize will escape the field and validate the direction against valid direction params
+    order: [[field, direction]],
+  };
+}

--- a/middleware/sorting.js
+++ b/middleware/sorting.js
@@ -1,0 +1,9 @@
+export default function (req, res, next) {
+  // If there is no 'orderBy', unset any direction
+  if (!req.query.orderBy) {
+    req.query.direction = undefined;
+  } else {
+    req.query.direction = req.query.direction || 'ASC'; // Sort by ascending by default
+  }
+  next();
+}

--- a/models/committee.js
+++ b/models/committee.js
@@ -1,6 +1,7 @@
 import DataTypes from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 import Officer from './officer';
 
 export default sequelize.define('committees', {
@@ -27,5 +28,13 @@ export default sequelize.define('committees', {
       };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'name',
+        'description',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/event.js
+++ b/models/event.js
@@ -3,6 +3,7 @@ import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 
 const moment = extendMoment(Moment);
 
@@ -87,10 +88,26 @@ export default sequelize.define('events', {
         },
       };
     },
+    // TODO: Deprecate This
     sort(sort) {
       return { order: [['startDate', sort]] };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'id',
+        'name',
+        'committeeName',
+        'startDate',
+        'endDate',
+        'description',
+        'location',
+        'link',
+        'image',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
   validate: {
     startDateBeforeEndDate() {

--- a/models/headcount.js
+++ b/models/headcount.js
@@ -3,6 +3,7 @@ import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 
 const moment = extendMoment(Moment);
 
@@ -50,5 +51,14 @@ export default sequelize.define('headcounts', {
       return { where: { userDce } };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'id',
+        'count',
+        'userDce',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/link.js
+++ b/models/link.js
@@ -1,6 +1,7 @@
 import DataTypes from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 
 export default sequelize.define('links', {
   shortLink: {
@@ -23,5 +24,13 @@ export default sequelize.define('links', {
 }, {
   scopes: {
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'shortLink',
+        'longLink',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/membership.js
+++ b/models/membership.js
@@ -3,6 +3,7 @@ import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 
 const moment = extendMoment(Moment);
 
@@ -74,5 +75,18 @@ export default sequelize.define('memberships', {
       };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'id',
+        'userDce',
+        'committeeName',
+        'startDate',
+        'endDate',
+        'reason',
+        'approved',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   }, // TODO: Validate startDateBeforeEndDate like in 'models/event.js'
 });

--- a/models/mentor.js
+++ b/models/mentor.js
@@ -2,6 +2,7 @@ import DataTypes from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
 import Specialty from './specialty';
+import sorting from '../helpers/sorting';
 
 export default sequelize.define('mentors', {
   startDate: {
@@ -44,5 +45,16 @@ export default sequelize.define('mentors', {
       };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'id',
+        'bio',
+        'userDce',
+        'startDate',
+        'endDate',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/officer.js
+++ b/models/officer.js
@@ -1,6 +1,7 @@
 import DataTypes from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 
 export default sequelize.define('officers', {
   title: {
@@ -69,5 +70,19 @@ export default sequelize.define('officers', {
       };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'id',
+        'title',
+        'email',
+        'primaryOfficer',
+        'committeName',
+        'userDce',
+        'startDate',
+        'endDate',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/quote.js
+++ b/models/quote.js
@@ -1,6 +1,7 @@
 import DataTypes from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 import Tag from './tag';
 
 export default sequelize.define('quotes', {
@@ -65,5 +66,14 @@ export default sequelize.define('quotes', {
       };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'id',
+        'body',
+        'description',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/specialty.js
+++ b/models/specialty.js
@@ -1,6 +1,7 @@
 import DataTypes from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 
 export default sequelize.define('specialties', {
   name: {
@@ -14,5 +15,12 @@ export default sequelize.define('specialties', {
 }, {
   scopes: {
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'name',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/tag.js
+++ b/models/tag.js
@@ -1,6 +1,7 @@
 import DataTypes from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 
 export default sequelize.define('tags', {
   name: {
@@ -14,5 +15,12 @@ export default sequelize.define('tags', {
 }, {
   scopes: {
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'name',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/models/user.js
+++ b/models/user.js
@@ -2,6 +2,7 @@ import DataTypes from 'sequelize';
 import Promise from 'bluebird';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
 import nconf from '../config';
 
 export default sequelize.define('users', {
@@ -63,5 +64,15 @@ export default sequelize.define('users', {
       return { where: { dce } };
     },
     paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'firstName',
+        'lastName',
+        'dce',
+        'image',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
   },
 });

--- a/routes/committees.js
+++ b/routes/committees.js
@@ -2,12 +2,13 @@ import { Router } from 'express';
 import Committee from '../models/committee';
 import scopify from '../helpers/scopify';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       const scopes = scopify(req.query, 'name', 'active');
       Committee
         .scope(scopes)

--- a/routes/events.js
+++ b/routes/events.js
@@ -3,13 +3,14 @@ import Event from '../models/event';
 import scopify from '../helpers/scopify';
 import { needs } from '../middleware/permissions';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 import ical from '../helpers/ical';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       const scopes = scopify(req.query, 'name', 'committee', 'location', 'between', 'before', 'after', 'featured', 'sort');
       if (req.accepts('json')) {
         Event

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -2,13 +2,14 @@ import { Router } from 'express';
 import Headcount from '../models/headcount';
 import scopify from '../helpers/scopify';
 import { needs } from '../middleware/permissions';
+import sorting from '../middleware/sorting';
 import paginate from '../middleware/paginate';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       const scopes = scopify(req.query, 'count', 'greaterThan', 'lessThan', 'between', 'date', 'user');
       Headcount.scope(scopes)
         .findAndCountAll()

--- a/routes/links.js
+++ b/routes/links.js
@@ -2,13 +2,14 @@ import { Router } from 'express';
 import Link from '../models/link';
 import scopify from '../helpers/scopify';
 import { needs } from '../middleware/permissions';
+import sorting from '../middleware/sorting';
 import paginate from '../middleware/paginate';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       const scopes = scopify(req.query);
       Link.scope(scopes)
         .findAndCountAll({

--- a/routes/memberships.js
+++ b/routes/memberships.js
@@ -6,6 +6,7 @@ import scopify from '../helpers/scopify';
 import Membership from '../models/membership';
 import User from '../models/user';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 import { needs, needsApprovedIndex, needsApprovedOne } from '../middleware/permissions';
 import verifyUser from '../middleware/verify-user';
 
@@ -13,7 +14,7 @@ const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/scoreboard')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       const scopes = scopify(req.query, 'user', 'active', 'between', 'approved');
       Membership
         .scope(scopes)
@@ -31,7 +32,7 @@ router
 
 router
   .route('/')
-  .get(verifyUser, paginate, needsApprovedIndex('memberships'), (req, res, next) => {
+  .get(verifyUser, paginate, sorting, needsApprovedIndex('memberships'), (req, res, next) => {
     const scopes = scopify(req.query, 'reason', 'committee', 'user', 'active', 'between', 'approved');
     Membership
       .scope(scopes)

--- a/routes/mentors.js
+++ b/routes/mentors.js
@@ -5,13 +5,14 @@ import User from '../models/user';
 import Specialty from '../models/specialty';
 import scopify from '../helpers/scopify';
 import { needs } from '../middleware/permissions';
+import sorting from '../middleware/sorting';
 import paginate from '../middleware/paginate';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-  .get(paginate, (req, res, next) => {
+  .get(paginate, sorting, (req, res, next) => {
     const scopes = scopify(req.query, 'specialty', 'user', 'time', 'day', 'active');
     Mentor
       .scope(scopes)

--- a/routes/officers.js
+++ b/routes/officers.js
@@ -6,12 +6,13 @@ import Committee from '../models/committee';
 import scopify from '../helpers/scopify';
 import { needs } from '../middleware/permissions';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       if (req.query.primary === 'true') {
         req.query.primary = true;
       } else if (req.query.primary === 'false') {

--- a/routes/quotes.js
+++ b/routes/quotes.js
@@ -6,12 +6,13 @@ import scopify from '../helpers/scopify';
 import { needs, needsApprovedIndex, needsApprovedOne } from '../middleware/permissions';
 import verifyUser from '../middleware/verify-user';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(verifyUser, paginate, needsApprovedIndex('quotes'), (req, res, next) => {
+    .get(verifyUser, paginate, sorting, needsApprovedIndex('quotes'), (req, res, next) => {
       const scopes = scopify(req.query, 'body', 'tag', 'search', 'approved');
       Quote
         .scope(scopes)

--- a/routes/specialties.js
+++ b/routes/specialties.js
@@ -2,12 +2,13 @@ import { Router } from 'express';
 import Specialty from '../models/specialty';
 import scopify from '../helpers/scopify';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       const scopes = scopify(req.query, 'active');
       Specialty
         .scope(scopes)

--- a/routes/tags.js
+++ b/routes/tags.js
@@ -2,12 +2,13 @@ import { Router } from 'express';
 import Tag from '../models/tag';
 import scopify from '../helpers/scopify';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       if (req.query.active === 'true') {
         req.query.active = true; // INNER JOIN quotes
       } else {

--- a/routes/users.js
+++ b/routes/users.js
@@ -2,13 +2,14 @@ import { Router } from 'express';
 import User from '../models/user';
 import scopify from '../helpers/scopify';
 import paginate from '../middleware/paginate';
+import sorting from '../middleware/sorting';
 import { needs } from '../middleware/permissions';
 
 const router = Router(); // eslint-disable-line new-cap
 
 router
   .route('/')
-    .get(paginate, (req, res, next) => {
+    .get(paginate, sorting, (req, res, next) => {
       const scopes = scopify(req.query, 'firstName', 'lastName');
       User
         .scope(scopes)


### PR DESCRIPTION
- 'orderBy' and 'direction' query params
- 'direction' defaults to 'ASC'
- Allowed sortable fields are whitelisted to prevent sorting by a nonexistent field

Fixes #25 