### PR TITLE
Update committee relationship to avoid sequelize duplicating on include

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -9,7 +9,7 @@ import Specialty from './specialty';
 import Tag from './tag';
 import User from './user';
 
-Committee.hasOne(Officer);
+Committee.hasMany(Officer);
 Committee.hasMany(Event);
 Committee.hasMany(Membership);
 


### PR DESCRIPTION
Updates the relationship for committees to officers to be a hasMany relationship, as we have multiple officers under the General committee, but the relationship didn't reflect that.
This resolves the issue where scoping committees by active officers (via an include) was resulting in duplicate committees (as each officer had "their own" General committee)