### PR TITLE
Update supertest/chai tests to use return Promise syntax to avoid timeouts

### DIFF
--- a/routes/events.js
+++ b/routes/events.js
@@ -35,7 +35,7 @@ router
       }
     })
     .post(needs('events', 'create'), (req, res, next) => {
-      Event.create(req.body, { fields: ['name', 'startDate', 'endDate', 'description', 'location', 'image', 'committeeName'] })
+      Event.create(req.body, { fields: ['name', 'startDate', 'endDate', 'description', 'location', 'link', 'image', 'committeeName'] })
         .then(event => res.status(201).send(event))
         .catch((err) => {
           err.status = 422;

--- a/test/routes/auth.js
+++ b/test/routes/auth.js
@@ -10,57 +10,54 @@ import { token } from '../helpers';
 
 describe('INTEGRATION TESTS: AUTH', function () {
   describe('GET /', function () {
-    it('Denies Unauthenticated Users', function (done) {
+    it('Denies Unauthenticated Users', function () {
       const expected = {
         error: 'not logged in',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/auth')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Gets the Current Logged In User', function (done) {
+    it('Gets the Current Logged In User', function () {
       const expected = {
         firstName: 'Test',
         lastName: 'User',
         dce: 'abc1234',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/auth')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('GET /googleClientID', function () {
-    it('Gets the Google Client ID', function (done) {
+    it('Gets the Google Client ID', function () {
       const expected = {
         token: nconf.get('auth').google.id,
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/auth/googleClientID')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('POST /:provider', function () {
-    it('Sends a Refresh Token', function (done) {
-      request(app)
+    it('Sends a Refresh Token', function () {
+      return request(app)
         .post('/api/v2/auth/refresh')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -69,22 +66,20 @@ describe('INTEGRATION TESTS: AUTH', function () {
           // not be the same as the original token.
           expect(response.body.token).to.not.be.undefined; // eslint-disable-line no-unused-expressions
           expect(response.body).to.not.deep.equal({ token });
-          done();
         });
     });
 
-    it('Does Not Support Unknown Providers', function (done) {
+    it('Does Not Support Unknown Providers', function () {
       const expected = {
         error: 'invalid provider',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/auth/unknown')
         .set('Authorization', `Bearer ${token}`)
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 

--- a/test/routes/committees.js
+++ b/test/routes/committees.js
@@ -9,7 +9,7 @@ import nconf from '../../config';
 
 describe('INTEGRATION TESTS: COMMITTEES', function () {
   describe('GET /', function () {
-    it('Returns Committees', function (done) {
+    it('Returns Committees', function () {
       const expected = {
         total: 4,
         perPage: nconf.get('pagination:perPage'),
@@ -42,16 +42,15 @@ describe('INTEGRATION TESTS: COMMITTEES', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/committees')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by an Existing Name', function (done) {
+    it('Filters by an Existing Name', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -66,16 +65,15 @@ describe('INTEGRATION TESTS: COMMITTEES', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/committees?name=Technology')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by an Non-existent Name', function (done) {
+    it('Filters by an Non-existent Name', function () {
       const expected = {
         total: 0,
         perPage: nconf.get('pagination:perPage'),
@@ -83,16 +81,15 @@ describe('INTEGRATION TESTS: COMMITTEES', function () {
         data: [],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/committees?name=Nope')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Active', function (done) {
+    it('Filters by Active', function () {
       const expected = {
         total: 2,
         perPage: nconf.get('pagination:perPage'),
@@ -113,17 +110,16 @@ describe('INTEGRATION TESTS: COMMITTEES', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/committees?active=${encodeURIComponent('2017-12-05T05:00:00.000Z')}`)
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
     // See: https://github.com/rit-sse/node-api/issues/67
-    it('Filters by Active When Multiple Officers Are Assigned to the Same Committee', function (done) {
+    it('Filters by Active When Multiple Officers Are Assigned to the Same Committee', function () {
       const expected = {
         total: 2,
         perPage: nconf.get('pagination:perPage'),
@@ -144,18 +140,17 @@ describe('INTEGRATION TESTS: COMMITTEES', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/committees?active=${encodeURIComponent('2017-01-05T05:00:00.000Z')}`)
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('GET /:id', function () {
-    it('Finds a Specific Committee', function (done) {
+    it('Finds a Specific Committee', function () {
       const expected = {
         name: 'Technology',
         description: 'tech',
@@ -163,26 +158,24 @@ describe('INTEGRATION TESTS: COMMITTEES', function () {
         updatedAt: '2017-12-01T05:00:00.000Z',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/committees/Technology')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find a Committee That Does Not Exist', function (done) {
+    it('Does Not Find a Committee That Does Not Exist', function () {
       const expected = {
         error: 'Committee not found',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/committees/Nope')
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });

--- a/test/routes/events.js
+++ b/test/routes/events.js
@@ -16,7 +16,7 @@ import {
 
 describe('INTEGRATION TESTS: EVENTS', function () {
   describe('GET /', function () {
-    it('Returns Events When Accepting JSON', function (done) {
+    it('Returns Events When Accepting JSON', function () {
       const expected = {
         total: 3,
         perPage: nconf.get('pagination:perPage'),
@@ -82,12 +82,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
       Promise.all([
         nakedURL,
         jsonExtension,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Filters by an Existing Name', function (done) {
+    it('Filters by an Existing Name', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -116,11 +114,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by an Non-existent Name', function (done) {
+    it('Filters by an Non-existent Name', function () {
       const expected = {
         total: 0,
         perPage: nconf.get('pagination:perPage'),
@@ -133,11 +130,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by an Existing Committee', function (done) {
+    it('Filters by an Existing Committee', function () {
       const expected = {
         total: 2,
         perPage: nconf.get('pagination:perPage'),
@@ -166,7 +162,7 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events?committee=Talks')
         .expect(200)
         .then((response) => {
@@ -176,11 +172,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by an Non-existent Committee', function (done) {
+    it('Filters by an Non-existent Committee', function () {
       const expected = {
         total: 0,
         perPage: nconf.get('pagination:perPage'),
@@ -188,16 +183,15 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         data: [],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events?committee=Unknown')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by an Existing Location', function (done) {
+    it('Filters by an Existing Location', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -216,7 +210,7 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events?location=GOL-1440')
         .expect(200)
         .then((response) => {
@@ -226,11 +220,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by an Non-existent Location', function (done) {
+    it('Filters by an Non-existent Location', function () {
       const expected = {
         total: 0,
         perPage: nconf.get('pagination:perPage'),
@@ -238,16 +231,15 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         data: [],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events?location=Unknown')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Between', function (done) {
+    it('Filters by Between', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -266,7 +258,7 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/events?between=${encodeURIComponent('2017-07-01T05:00:00.000Z')}/${encodeURIComponent('2017-11-01T05:00:00.000Z')}`)
         .expect(200)
         .then((response) => {
@@ -276,11 +268,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Before', function (done) {
+    it('Filters by Before', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -299,7 +290,7 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/events?before=${encodeURIComponent('2017-07-01T05:00:00.000Z')}`)
         .expect(200)
         .then((response) => {
@@ -309,11 +300,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by After', function (done) {
+    it('Filters by After', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -332,7 +322,7 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/events?after=${encodeURIComponent('2017-11-01T05:00:00.000Z')}`)
         .expect(200)
         .then((response) => {
@@ -342,11 +332,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Featured', function (done) {
+    it('Filters by Featured', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -365,7 +354,7 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events?featured')
         .expect(200)
         .then((response) => {
@@ -375,11 +364,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Sort', function (done) {
+    it('Filters by Sort', function () {
       const expected = {
         total: 3,
         perPage: nconf.get('pagination:perPage'),
@@ -418,7 +406,7 @@ describe('INTEGRATION TESTS: EVENTS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events?sort=DESC')
         .expect(200)
         .then((response) => {
@@ -428,11 +416,10 @@ describe('INTEGRATION TESTS: EVENTS', function () {
             delete event.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Returns a Calendar Event When Accepting ICS', function (done) {
+    it('Returns a Calendar Event When Accepting ICS', function () {
       const expected =
 `BEGIN:VCALENDAR
 CALSCALE:GREGORIAN
@@ -492,46 +479,42 @@ END:VCALENDAR`;
           expect(response.text).to.deep.equal(expected);
         });
 
-      Promise.all([
+      return Promise.all([
         nakedURL,
         icsExtension,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Does Not Accept Requests Not Accepting JSON or ICS', function (done) {
+    it('Does Not Accept Requests Not Accepting JSON or ICS', function () {
       const expected = {
         error: 'xml is not acceptable',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events')
         .set('accept', 'xml')
         .expect(406)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('POST /', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/events')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need Low Permissions be an Officer or Primary Officer
       const expected = {
         error: 'User does not have permission: create events',
@@ -566,16 +549,14 @@ END:VCALENDAR`;
         .send(eventInput)
         .expect(201);
 
-      Promise.all([
+      return Promise.all([
         userHigh,
         primaryLow,
         officerLow,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Creates an Event', function (done) {
+    it('Creates an Event', function () {
       const expected = {
         name: 'A Cool Talk',
         committeeName: 'Talks',
@@ -587,7 +568,7 @@ END:VCALENDAR`;
         link: null,
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/events')
         .set('Authorization', `Bearer ${token}`)
         .send(expected)
@@ -597,16 +578,15 @@ END:VCALENDAR`;
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Start Date to be Before End Date', function (done) {
+    it('Requires Start Date to be Before End Date', function () {
       const expected = {
         error: 'Validation error: Start date must be before the end date',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/events')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -619,29 +599,27 @@ END:VCALENDAR`;
         .expect(422)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Errors When Insufficient Fields Provided', function (done) {
+    it('Errors When Insufficient Fields Provided', function () {
       const expected = {
         error: 'notNull Violation: name cannot be null,\nnotNull Violation: startDate cannot be null,\nnotNull Violation: endDate cannot be null,\nnotNull Violation: location cannot be null',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/events')
         .set('Authorization', `Bearer ${token}`)
         .send({})
         .expect(422)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('GET /:id', function () {
-    it('Gets a Specific Event', function (done) {
+    it('Gets a Specific Event', function () {
       const expected = {
         id: 1,
         name: 'Review Session',
@@ -654,7 +632,7 @@ END:VCALENDAR`;
         description: null,
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events/1')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -662,42 +640,39 @@ END:VCALENDAR`;
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find a Non-existent Event', function (done) {
+    it('Does Not Find a Non-existent Event', function () {
       const expected = {
         error: 'Event not found',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/events/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('PUT /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/events/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need High Permissions be an Officer or Primary Officer
       const expected = {
         error: 'User does not have permission: update events',
@@ -744,18 +719,16 @@ END:VCALENDAR`;
         .send(eventInput)
         .expect(200);
 
-      Promise.all([
+      return Promise.all([
         primaryLow,
         officerLow,
         userHigh,
         primaryHigh,
         officerHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Updates a Specific Event', function (done) {
+    it('Updates a Specific Event', function () {
       const expected = {
         id: 1,
         name: 'Lunch and Learn',
@@ -768,7 +741,7 @@ END:VCALENDAR`;
         image: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/events/1')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -779,42 +752,39 @@ END:VCALENDAR`;
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find and Update a Non-existent Event', function (done) {
+    it('Does Not Find and Update a Non-existent Event', function () {
       const expected = {
         error: 'Event not found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/events/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('DELETE /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .delete('/api/v2/events/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need High Permissions be an Officer or Primary Officer
       const expected = {
         error: 'User does not have permission: destroy events',
@@ -855,18 +825,16 @@ END:VCALENDAR`;
         .set('Authorization', `Bearer ${highPermissionOfficerToken}`)
         .expect(204);
 
-      Promise.all([
+      return Promise.all([
         primaryLow,
         officerLow,
         userHigh,
         primaryHigh,
         officerHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Deletes a Specific Event', function (done) {
+    it('Deletes a Specific Event', function () {
       request(app)
         .delete('/api/v2/events/1')
         .set('Authorization', `Bearer ${token}`)
@@ -875,14 +843,11 @@ END:VCALENDAR`;
           request(app)
             .get('/api/v2/events/1')
             .set('Authorization', `Bearer ${token}`)
-            .expect(404)
-            .then(() => {
-              done();
-            });
+            .expect(404);
         });
     });
 
-    it('Does Not Find and Delete a Non-existent Event', function (done) {
+    it('Does Not Find and Delete a Non-existent Event', function () {
       const expected = {
         error: 'Event not found',
       };
@@ -893,7 +858,6 @@ END:VCALENDAR`;
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });

--- a/test/routes/memberships.js
+++ b/test/routes/memberships.js
@@ -43,7 +43,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
   });
 
   describe('GET /', function () {
-    it('Gets Approved Memberships', function (done) {
+    it('Gets Approved Memberships', function () {
       const expected = {
         total: 2,
         perPage: nconf.get('pagination:perPage'),
@@ -84,7 +84,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/memberships')
         .expect(200)
         .then((response) => {
@@ -94,11 +94,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
             delete membership.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need Low Permissions be Primary Officer for Pending and Denied
       const expected = {
         error: 'User does not have permission: unapproved memberships',
@@ -156,7 +155,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         .get('/api/v2/memberships')
         .expect(200);
 
-      Promise.all([
+      return Promise.all([
         officerHigh,
         userHigh,
         primaryHigh,
@@ -164,12 +163,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         userHigh2,
         primaryHigh2,
         anyone,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Filters by Reason', function (done) {
+    it('Filters by Reason', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -194,7 +191,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/memberships?reason=${encodeURIComponent('Giving a Talk')}`)
         .expect(200)
         .then((response) => {
@@ -204,11 +201,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
             delete membership.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Committee', function (done) {
+    it('Filters by Committee', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -233,7 +229,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/memberships?committee=Talks')
         .expect(200)
         .then((response) => {
@@ -243,11 +239,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
             delete membership.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by User', function (done) {
+    it('Filters by User', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -272,7 +267,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/memberships?user=axy9999')
         .expect(200)
         .then((response) => {
@@ -282,11 +277,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
             delete membership.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Active (and Approved)', function (done) {
+    it('Filters by Active (and Approved)', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -311,7 +305,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/memberships?active=${encodeURIComponent('2017-11-01T05:00:00.000Z')}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -322,11 +316,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
             delete membership.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Between Start Date (and Approved)', function (done) {
+    it('Filters by Between Start Date (and Approved)', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -351,7 +344,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/memberships?between=${encodeURIComponent('2017-05-01T05:00:00.000Z')}/${encodeURIComponent('2017-09-01T05:00:00.000Z')}`)
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -362,11 +355,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
             delete membership.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Pending', function (done) {
+    it('Filters by Pending', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -391,7 +383,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/memberships?approved=null')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -402,11 +394,10 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
             delete membership.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Denied', function (done) {
+    it('Filters by Denied', function () {
       const expected = {
         total: 0,
         perPage: nconf.get('pagination:perPage'),
@@ -414,33 +405,31 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         data: [],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/memberships?approved=false')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('POST /', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/memberships')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need Low Permissions be an Officer or Primary Officer
       const expected = {
         error: 'User does not have permission: create memberships',
@@ -475,16 +464,14 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         .send(membershipInput)
         .expect(201);
 
-      Promise.all([
+      return Promise.all([
         userHigh,
         primaryLow,
         officerLow,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Creates a Membership', function (done) {
+    it('Creates a Membership', function () {
       const expected = {
         reason: 'A Nice Person',
         startDate: '2017-06-15T05:00:00.000Z',
@@ -502,7 +489,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         },
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/memberships')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -518,29 +505,27 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Errors When Insufficient Fields Provided', function (done) {
+    it('Errors When Insufficient Fields Provided', function () {
       const expected = {
         error: 'notNull Violation: reason cannot be null',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/memberships')
         .set('Authorization', `Bearer ${token}`)
         .send({})
         .expect(422)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('GET /:id', function () {
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need Low Permissions be Primary Officer
       const expected = {
         error: 'User does not have permission: unapproved memberships',
@@ -568,16 +553,14 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         .set('Authorization', `Bearer ${token}`)
         .expect(200);
 
-      Promise.all([
+      return Promise.all([
         officerHigh,
         userHigh,
         primaryHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Gets a Specific Membership', function (done) {
+    it('Gets a Specific Membership', function () {
       const expected = {
         id: 2,
         reason: 'Helping Out',
@@ -596,7 +579,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         },
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/memberships/2')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -604,42 +587,39 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find a Non-existent Membership', function (done) {
+    it('Does Not Find a Non-existent Membership', function () {
       const expected = {
         error: 'Membership not found',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/memberships/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('PUT /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/memberships/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need Low Permissions be Primary Officer
       const expected = {
         error: 'User does not have permission: update memberships',
@@ -672,16 +652,14 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         .send(membershipInput)
         .expect(200);
 
-      Promise.all([
+      return Promise.all([
         officerHigh,
         userHigh,
         primaryHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Updates a Specific Membership', function (done) {
+    it('Updates a Specific Membership', function () {
       const expected = {
         id: 2,
         reason: 'Because',
@@ -700,7 +678,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         },
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/memberships/2')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -711,42 +689,39 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find and Update a Non-existent Membership', function (done) {
+    it('Does Not Find and Update a Non-existent Membership', function () {
       const expected = {
         error: 'Membership not found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/memberships/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('DELETE /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .delete('/api/v2/memberships/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need High Permissions be Primary Officer
       const expected = {
         error: 'User does not have permission: destroy memberships',
@@ -782,18 +757,16 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
         .set('Authorization', `Bearer ${token}`)
         .expect(204);
 
-      Promise.all([
+      return Promise.all([
         primaryLow,
         officerHigh,
         userHigh,
         primaryHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Deletes a Specific Membership', function (done) {
-      request(app)
+    it('Deletes a Specific Membership', function () {
+      return request(app)
         .delete('/api/v2/memberships/1')
         .set('Authorization', `Bearer ${token}`)
         .expect(204)
@@ -801,25 +774,21 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
           request(app)
             .get('/api/v2/memberships/1')
             .set('Authorization', `Bearer ${token}`)
-            .expect(404)
-            .then(() => {
-              done();
-            });
+            .expect(404);
         });
     });
 
-    it('Does Not Find and Delete a Non-existent Membership', function (done) {
+    it('Does Not Find and Delete a Non-existent Membership', function () {
       const expected = {
         error: 'Membership not found',
       };
 
-      request(app)
+      return request(app)
         .delete('/api/v2/memberships/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });

--- a/test/routes/officers.js
+++ b/test/routes/officers.js
@@ -15,7 +15,7 @@ import {
 
 describe('INTEGRATION TESTS: OFFICERS', function () {
   describe('GET /', function () {
-    it('Gets Officers', function (done) {
+    it('Gets Officers', function () {
       const expected = {
         total: 5,
         perPage: nconf.get('pagination:perPage'),
@@ -109,7 +109,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/officers')
         .expect(200)
         .then((response) => {
@@ -119,11 +119,10 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
             delete officer.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Title', function (done) {
+    it('Filters by Title', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -149,7 +148,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/officers?title=${encodeURIComponent('Art Head')}`)
         .expect(200)
         .then((response) => {
@@ -159,11 +158,10 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
             delete officer.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Email', function (done) {
+    it('Filters by Email', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -189,7 +187,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/officers?email=art')
         .expect(200)
         .then((response) => {
@@ -199,11 +197,10 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
             delete officer.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by User', function (done) {
+    it('Filters by User', function () {
       const expected = {
         total: 2,
         perPage: nconf.get('pagination:perPage'),
@@ -246,7 +243,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/officers?user=br4321')
         .expect(200)
         .then((response) => {
@@ -256,11 +253,10 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
             delete officer.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Primary', function (done) {
+    it('Filters by Primary', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -286,7 +282,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/officers?primary=true')
         .expect(200)
         .then((response) => {
@@ -296,11 +292,10 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
             delete officer.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Committee', function (done) {
+    it('Filters by Committee', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -326,7 +321,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/officers?committee=Technology')
         .expect(200)
         .then((response) => {
@@ -336,11 +331,10 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
             delete officer.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Active', function (done) {
+    it('Filters by Active', function () {
       const expected = {
         total: 3,
         perPage: nconf.get('pagination:perPage'),
@@ -400,7 +394,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get(`/api/v2/officers?active=${encodeURIComponent('2017-12-05T05:00:00.000Z')}`)
         .expect(200)
         .then((response) => {
@@ -410,27 +404,25 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
             delete officer.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('POST /', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/officers')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need High Permissions be Primary Officer
       const expected = {
         error: 'User does not have permission: create officers',
@@ -476,14 +468,12 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         .send(officerInput)
         .expect(201);
 
-      Promise.all([
+      return Promise.all([
         primaryLow,
         userHigh,
         primaryHigh,
         officerHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
     xit('Creates a New Committee if there is No Officer belonging to that Committee', function (done) {
@@ -496,12 +486,12 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
       done();
     });
 
-    it('Errors When Insufficient Fields Provided', function (done) {
+    it('Errors When Insufficient Fields Provided', function () {
       const expected = {
         error: 'notNull Violation: title cannot be null,\nnotNull Violation: email cannot be null',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/officers')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -510,13 +500,12 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         .expect(422)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('GET /:id', function () {
-    it('Gets a Specific Officer', function (done) {
+    it('Gets a Specific Officer', function () {
       const expected = {
         id: 2,
         title: 'Technology Head',
@@ -536,7 +525,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         },
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/officers/2')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -544,42 +533,39 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find a Non-existent Officer', function (done) {
+    it('Does Not Find a Non-existent Officer', function () {
       const expected = {
         error: 'Officer not found',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/officers/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('PUT /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/officers/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need High Permissions be Primary Officer
       const expected = {
         error: 'User does not have permission: update officers',
@@ -620,17 +606,15 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         .send(officerInput)
         .expect(200);
 
-      Promise.all([
+      return Promise.all([
         primaryLow,
         userHigh,
         primaryHigh,
         officerHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Updates a Specific Officer', function (done) {
+    it('Updates a Specific Officer', function () {
       const expected = {
         id: 2,
         title: 'Best Officer',
@@ -650,7 +634,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         },
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/officers/2')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -661,42 +645,39 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find and Update a Non-existent Officer', function (done) {
+    it('Does Not Find and Update a Non-existent Officer', function () {
       const expected = {
         error: 'Officer not found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/officers/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('DELETE /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .delete('/api/v2/officers/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need High Permissions be Primary Officer
       const expected = {
         error: 'User does not have permission: destroy officers',
@@ -732,18 +713,16 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
         .set('Authorization', `Bearer ${token}`)
         .expect(204);
 
-      Promise.all([
+      return Promise.all([
         primaryLow,
         officerHigh,
         userHigh,
         primaryHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
-    it('Deletes a Specific Officer', function (done) {
-      request(app)
+    it('Deletes a Specific Officer', function () {
+      return request(app)
         .delete('/api/v2/officers/1')
         .set('Authorization', `Bearer ${token}`)
         .expect(204)
@@ -751,25 +730,21 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
           request(app)
             .get('/api/v2/officers/1')
             .set('Authorization', `Bearer ${token}`)
-            .expect(404)
-            .then(() => {
-              done();
-            });
+            .expect(404);
         });
     });
 
-    it('Does Not Find and Delete a Non-existent Officer', function (done) {
+    it('Does Not Find and Delete a Non-existent Officer', function () {
       const expected = {
         error: 'Officer not found',
       };
 
-      request(app)
+      return request(app)
         .delete('/api/v2/officers/100')
         .set('Authorization', `Bearer ${token}`)
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });

--- a/test/routes/quotes.js
+++ b/test/routes/quotes.js
@@ -16,7 +16,7 @@ import {
 
 describe('INTEGRATION TESTS: QUOTES', function () {
   describe('GET /', function () {
-    it('Gets Approved Quotes (In Descending Order)', function (done) {
+    it('Gets Approved Quotes (In Descending Order)', function () {
       const expected = {
         total: 3,
         perPage: nconf.get('pagination:perPage'),
@@ -43,7 +43,7 @@ describe('INTEGRATION TESTS: QUOTES', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/qdb/quotes')
         .expect(200)
         .then((response) => {
@@ -56,7 +56,6 @@ describe('INTEGRATION TESTS: QUOTES', function () {
             });
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
@@ -93,17 +92,16 @@ describe('INTEGRATION TESTS: QUOTES', function () {
   });
 
   describe('POST /', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/qdb/quotes')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
@@ -122,19 +120,18 @@ describe('INTEGRATION TESTS: QUOTES', function () {
       done();
     });
 
-    it('Errors When Insufficient Fields Provided', function (done) {
+    it('Errors When Insufficient Fields Provided', function () {
       const expected = {
         error: 'notNull Violation: body cannot be null',
       };
 
-      request(app)
+      return request(app)
         .post('/api/v2/qdb/quotes')
         .set('Authorization', `Bearer ${token}`)
         .send({})
         .expect(422)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
@@ -157,17 +154,16 @@ describe('INTEGRATION TESTS: QUOTES', function () {
   });
 
   describe('PUT /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/qdb/quotes/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
@@ -198,17 +194,16 @@ describe('INTEGRATION TESTS: QUOTES', function () {
   });
 
   describe('DELETE /:id', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .delete('/api/v2/qdb/quotes/1')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 

--- a/test/routes/tags.js
+++ b/test/routes/tags.js
@@ -9,7 +9,7 @@ import nconf from '../../config';
 
 describe('INTEGRATION TESTS: TAGS', function () {
   describe('GET /', function () {
-    it('Gets All Tags', function (done) {
+    it('Gets All Tags', function () {
       const expected = {
         total: 4,
         perPage: nconf.get('pagination:perPage'),
@@ -30,7 +30,7 @@ describe('INTEGRATION TESTS: TAGS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/qdb/tags')
         .expect(200)
         .then((response) => {
@@ -39,11 +39,10 @@ describe('INTEGRATION TESTS: TAGS', function () {
             delete tag.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Gets Only Active Tags', function (done) {
+    it('Gets Only Active Tags', function () {
       const expected = {
         total: 3,
         perPage: nconf.get('pagination:perPage'),
@@ -61,7 +60,7 @@ describe('INTEGRATION TESTS: TAGS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/qdb/tags?active=true')
         .expect(200)
         .then((response) => {
@@ -70,7 +69,6 @@ describe('INTEGRATION TESTS: TAGS', function () {
             delete tag.updatedAt;
           });
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });

--- a/test/routes/users.js
+++ b/test/routes/users.js
@@ -16,7 +16,7 @@ import {
 
 describe('INTEGRATION TESTS: USERS', function () {
   describe('GET /', function () {
-    it('Gets Users', function (done) {
+    it('Gets Users', function () {
       const expected = {
         total: 5,
         perPage: nconf.get('pagination:perPage'),
@@ -65,16 +65,15 @@ describe('INTEGRATION TESTS: USERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/users')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by First Name', function (done) {
+    it('Filters by First Name', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -91,16 +90,15 @@ describe('INTEGRATION TESTS: USERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/users?firstName=Bob')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Filters by Last Name', function (done) {
+    it('Filters by Last Name', function () {
       const expected = {
         total: 1,
         perPage: nconf.get('pagination:perPage'),
@@ -117,18 +115,17 @@ describe('INTEGRATION TESTS: USERS', function () {
         ],
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/users?lastName=Lovelace')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('GET /:dce', function () {
-    it('Gets a Specific User by Their DCE', function (done) {
+    it('Gets a Specific User by Their DCE', function () {
       const expected = {
         firstName: 'Ada',
         lastName: 'Lovelace',
@@ -138,46 +135,43 @@ describe('INTEGRATION TESTS: USERS', function () {
         updatedAt: '2017-01-01T05:00:00.000Z',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/users/axy9999')
         .expect(200)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Does Not Find a Non-existent User', function (done) {
+    it('Does Not Find a Non-existent User', function () {
       const expected = {
         error: 'User not found',
       };
 
-      request(app)
+      return request(app)
         .get('/api/v2/users/xxx7777')
         .expect(404)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });
 
   describe('PUT /:dce', function () {
-    it('Requires Authentication', function (done) {
+    it('Requires Authentication', function () {
       const expected = {
         error: 'No authorization token was found',
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/users/abc1234')
         .expect(401)
         .then((response) => {
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Requires Expected Permissions', function (done) {
+    it('Requires Expected Permissions', function () {
       // Need High Permissions and be an Officer or Primary Officer
       const expected = {
         error: 'User does not have permission: update users',
@@ -224,19 +218,17 @@ describe('INTEGRATION TESTS: USERS', function () {
         })
         .expect(200);
 
-      Promise.all([
+      return Promise.all([
         primaryLow,
         officerLow,
         userHigh,
         primaryHigh,
         officerHigh,
-      ]).then(() => {
-        done();
-      });
+      ]);
     });
 
     // TODO: Implement this functionality
-    it("Updates a User's First Name if Provided in the Request Body", function (done) {
+    it("Updates a User's First Name if Provided in the Request Body", function () {
       const expected = {
         firstName: 'Robert',
         lastName: 'Ross',
@@ -246,7 +238,7 @@ describe('INTEGRATION TESTS: USERS', function () {
         updatedAt: '2016-01-01T05:00:00.000Z', // NOTE: Expected to be different
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/users/br4321')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -260,16 +252,14 @@ describe('INTEGRATION TESTS: USERS', function () {
           delete response.body.updatedAt;
           delete expected.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         })
         .catch(() => {
           console.warn('Not Implemented.'); // eslint-disable-line no-console
-          done();
         });
     });
 
     // TODO: Implement this functionality
-    it("Updates a User's Last Name if Provided in the Request Body", function (done) {
+    it("Updates a User's Last Name if Provided in the Request Body", function () {
       const expected = {
         firstName: 'Bob',
         lastName: 'Roberts',
@@ -279,7 +269,7 @@ describe('INTEGRATION TESTS: USERS', function () {
         updatedAt: '2016-01-01T05:00:00.000Z', // NOTE: Expected to be different
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/users/br4321')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -293,15 +283,13 @@ describe('INTEGRATION TESTS: USERS', function () {
           delete response.body.updatedAt;
           delete expected.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         })
         .catch(() => {
           console.warn('Not Implemented.'); // eslint-disable-line no-console
-          done();
         });
     });
 
-    it("Updates a User's First and Last Name if they were Not Previously Defined", function (done) {
+    it("Updates a User's First and Last Name if they were Not Previously Defined", function () {
       const expected = {
         firstName: 'Unknown',
         lastName: 'Jones',
@@ -309,7 +297,7 @@ describe('INTEGRATION TESTS: USERS', function () {
         image: null,
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/users/unk0000')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -321,11 +309,10 @@ describe('INTEGRATION TESTS: USERS', function () {
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it("Updates a User's Image", function (done) {
+    it("Updates a User's Image", function () {
       const expected = {
         firstName: 'Bob',
         lastName: 'Ross',
@@ -335,7 +322,7 @@ describe('INTEGRATION TESTS: USERS', function () {
         updatedAt: '2016-01-01T05:00:00.000Z', // NOTE: Expected to be different
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/users/br4321')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -349,11 +336,10 @@ describe('INTEGRATION TESTS: USERS', function () {
           delete response.body.updatedAt;
           delete expected.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
 
-    it('Creates a New User if a User with the Provided DCE Does Not Exist', function (done) {
+    it('Creates a New User if a User with the Provided DCE Does Not Exist', function () {
       const expected = {
         firstName: 'John',
         lastName: 'Renner',
@@ -361,7 +347,7 @@ describe('INTEGRATION TESTS: USERS', function () {
         image: null,
       };
 
-      request(app)
+      return request(app)
         .put('/api/v2/users/jmr2258')
         .set('Authorization', `Bearer ${token}`)
         .send({
@@ -373,7 +359,6 @@ describe('INTEGRATION TESTS: USERS', function () {
           delete response.body.createdAt;
           delete response.body.updatedAt;
           expect(response.body).to.deep.equal(expected);
-          done();
         });
     });
   });


### PR DESCRIPTION
Updates all async tests to avoid using done() when possible, as supertest/chai now handles async properly as long as you return the request/promise. This mitigates the timeout issues where tests are perceived as passing/failing because the previous test times out (waiting on a resolve that'll never happen as it's in a reject state).

**Example from https://github.com/visionmedia/supertest**
```javascript
describe('GET /users', function() {
  it('responds with json', function() {
    return request(app)
      .get('/users')
      .set('Accept', 'application/json')
      .expect('Content-Type', /json/)
      .expect(200)
      .then(response => {
          assert(response.body.email, 'foo@bar.com')
      })
  });
});
```

An alternative is to use `.end((err, res) => {...}` where you handle the err case and `return done(err)` and if success, `return done()` but this is almost as messy as it was before, and complicates the tests using Promise.all(...)