### PR TITLE
Exclude officer field from committee model and requests

### DIFF
--- a/models/committee.js
+++ b/models/committee.js
@@ -24,6 +24,8 @@ export default sequelize.define('committees', {
       return {
         include: [{
           model: Officer.scope({ method: ['active', date] }),
+          attributes: [],
+          includeIgnoreAttributes: false,
         }],
       };
     },

--- a/routes/committees.js
+++ b/routes/committees.js
@@ -13,16 +13,20 @@ router
       Committee
         .scope(scopes)
         .findAndCountAll()
-        .then(result => res.send({
-          total: result.count,
-          perPage: req.query.perPage,
-          currentPage: req.query.page,
-          data: result.rows.map((committee) => {
+        .then(result => {
+          const uniqueCommittees = {};
+          result.rows.forEach((committee) => {
             const c = committee.get({ plain: true });
             Reflect.deleteProperty(c, 'officer');
-            return c;
-          }),
-        }))
+            uniqueCommittees[c.name] = c;
+          });
+          return res.send({
+            total: Object.keys(uniqueCommittees).length,
+            perPage: req.query.perPage,
+            currentPage: req.query.page,
+            data: Object.values(uniqueCommittees),
+          })
+        })
         .catch(err => next(err));
     });
 


### PR DESCRIPTION
Since committees do a join with officers when specifying the active field, the officers field is being appended to the committees results.

We only want the commitees' fields, and not those of the officers, so this excludes the officers attributes. 
Unfortunately, the id attribute of the officer cannot be excluded on the include (because sequelize requires it), so duplicates are still being returned when requesting the active scope when there are multiple officers in one committee.

The changes in `routes/commitees.js` resolve this, but aren't the prettiest (and ideally we can resolve this in a different way)