### PR TITLE
Handle slashes in go links

### DIFF
--- a/routes/links.js
+++ b/routes/links.js
@@ -55,7 +55,7 @@ router
     });
 
 router
-  .route('/:shortLink')
+  .route('/:shortLink(*)')
     .get((req, res, next) => {
       Link
         .findById(req.params.shortLink.toLocaleLowerCase())


### PR DESCRIPTION
Problem:
If a go-link has a / in its name, any PUT/DELETEs referencing it will fail, as the / causes ExpressJS to interpret the request as a separate route.

Solution:
By using a wildcard regxp for the route path (https://expressjs.com/en/guide/routing.html#route-paths)
eg: /:shortLink(*)
ExpressJS will glob anything after the matching part of the route, handling the remainder appropriately.
req.params.shortLink will still return back the whole go-link, so this should have no impact on other links, even if they also start with the same prefix/