### PR TITLE
Update sequelize to v5

### DIFF
--- a/config/permissions.js
+++ b/config/permissions.js
@@ -4,7 +4,7 @@
 // their permissions level and group assignment have to allow them to do so.
 //
 // Permission level is 'at least', so someone with
-// a 'low' permission cannot do 'high' permisison actions but
+// a 'low' permission cannot do 'high' permission actions but
 // someone with a 'high' permission can do 'low' permission actions.
 // Permission level is based on the provider they used to authenticate (eg. Google, Slack).
 //

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -1,4 +1,4 @@
-import Sequelize from 'sequelize';
+import { Sequelize } from 'sequelize';
 import nconf from './index';
 
 const env = nconf.get('NODE_ENV');

--- a/events/membership.js
+++ b/events/membership.js
@@ -25,55 +25,64 @@ const sendCongratsEmail = (user, secretary = null) => mailer.sendMail({
 });
 
 // If this is the first membership someone receives during the semester, send them a congrats email
-Membership.afterUpdate((membership) => {
-  const previousApproved = membership.previous('approved');
-  // Attempt to send email if this membership is being approved
-  if (membership.approved && (previousApproved === null || previousApproved === false)) {
-    // Count all active approved memberships for this user
-    Membership
-      .scope([
-        { method: ['user', membership.userDce] },
-        { method: ['approved', true] },
-        { method: ['active', moment().toISOString()] },
-      ])
-      .count()
-      .then((count) => {
-        // If there is only 1, then we can assume this is the first approved membership
-        // this person has received this semester, so we'll send them an email.
-        //
-        // Edge cases:
-        // 1. A User had 1 membership. It was deleted. They receieved another membership. They would receive a second email.
-        // 2. A User had 1 membership. It was unapproved. It was approved. They would receive a second email.
-        //
-        // We're fine with both cases because they're infrequent, if they occur at all
-        // – a user would be reminded of membership details which is ¯\_(ツ)_/¯
-        // Additionally, the only people who can approve memberships are primary officers,
-        // so we can trust that they won't abuse their power and spam someone's inbox.
-        if (count === 1) {
-          Promise
-            .all([
-              // Reload the membership to get the User associated with it
-              membership.reload({ include: [User] }),
-              // Find the current SSE Secretary
-              Officer
-                .scope([
-                  { method: ['title', 'Secretary'] },
-                  { method: ['active', moment().toISOString()] },
-                ])
-                .findAll({ include: [User] }),
-            ])
-            .then((values) => {
-              const user = values[0].user;
-              const secretary = values[1][0].user;
-              // Don't send emails during testing
-              if (config.get('NODE_ENV') !== 'test') {
-                console.log(`${moment().toISOString()}: Sending membership email to ${user.dce}@rit.edu`); // eslint-disable-line no-console
-                sendCongratsEmail(user, secretary);
-              }
-            });
-        }
-      });
-  }
-});
+Membership.hooks = {
+  afterUpdate: (membership) => {
+    const previousApproved = membership.previous('approved');
+    // Attempt to send email if this membership is being approved
+    if (membership.approved && (previousApproved === null || previousApproved === false)) {
+      // Count all active approved memberships for this user
+      Membership
+        .scope([
+          { method: ['user', membership.userDce] },
+          { method: ['approved', true] },
+          {
+            method: ['active', moment()
+              .toISOString()],
+          },
+        ])
+        .count()
+        .then((count) => {
+          // If there is only 1, then we can assume this is the first approved membership
+          // this person has received this semester, so we'll send them an email.
+          //
+          // Edge cases:
+          // 1. A User had 1 membership. It was deleted. They received another membership. They would receive a second email.
+          // 2. A User had 1 membership. It was unapproved. It was approved. They would receive a second email.
+          //
+          // We're fine with both cases because they're infrequent, if they occur at all
+          // – a user would be reminded of membership details which is ¯\_(ツ)_/¯
+          // Additionally, the only people who can approve memberships are primary officers,
+          // so we can trust that they won't abuse their power and spam someone's inbox.
+          if (count === 1) {
+            Promise
+              .all([
+                // Reload the membership to get the User associated with it
+                membership.reload({ include: [User] }),
+                // Find the current SSE Secretary
+                Officer
+                  .scope([
+                    { method: ['title', 'Secretary'] },
+                    {
+                      method: ['active', moment()
+                        .toISOString()],
+                    },
+                  ])
+                  .findAll({ include: [User] }),
+              ])
+              .then((values) => {
+                const user = values[0].user;
+                const secretary = values[1][0].user;
+                // Don't send emails during testing
+                if (config.get('NODE_ENV') !== 'test') {
+                  console.log(`${moment()
+                    .toISOString()}: Sending membership email to ${user.dce}@rit.edu`); // eslint-disable-line no-console
+                  sendCongratsEmail(user, secretary);
+                }
+              });
+          }
+        });
+    }
+  },
+};
 
 export default Membership;

--- a/middleware/permissions.js
+++ b/middleware/permissions.js
@@ -3,7 +3,7 @@ import User from '../models/user';
 export function needs(endpoint, action) {
   return (req, res, next) => {
     User
-      .findById(req.auth.user.dce)
+      .findByPk(req.auth.user.dce)
       .then(user => user.can(endpoint, action, req.auth.level))
       .then(() => next())
       .catch(() => next({
@@ -35,7 +35,7 @@ export function needsApprovedIndex(endpoint) {
     }
 
     User
-      .findById(req.auth.user.dce)
+      .findByPk(req.auth.user.dce)
       .then(user => user.can(endpoint, 'unapproved', req.auth.level))
       .then(() => next())
       .catch(() => {
@@ -54,7 +54,7 @@ export function needsApprovedOne(endpoint) {
       return next();
     }
     User
-      .findById(req.auth.user.dce)
+      .findByPk(req.auth.user.dce)
       .then(user => user.can(endpoint, 'unapproved', req.auth.level))
       .then(() => {
         req.auth.allowed = true;

--- a/models/event.js
+++ b/models/event.js
@@ -1,4 +1,4 @@
-import DataTypes from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import sequelize from '../config/sequelize';
@@ -61,7 +61,7 @@ export default sequelize.define('events', {
       return {
         where: {
           startDate: {
-            $lt: date,
+            [Op.lt]: date,
           },
         },
       };
@@ -70,20 +70,20 @@ export default sequelize.define('events', {
       return {
         where: {
           startDate: {
-            $gt: date,
+            [Op.gt]: date,
           },
         },
       };
     },
     featured() {
-      return { where: { image: { $ne: null } } };
+      return { where: { image: { [Op.ne]: null } } };
     },
     between(range) {
       const dates = moment.range(range);
       return {
         where: {
           startDate: {
-            $between: [dates.start.toDate(), dates.end.toDate()],
+            [Op.between]: [dates.start.toDate(), dates.end.toDate()],
           },
         },
       };

--- a/models/headcount.js
+++ b/models/headcount.js
@@ -1,4 +1,4 @@
-import DataTypes from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import sequelize from '../config/sequelize';
@@ -18,17 +18,17 @@ export default sequelize.define('headcounts', {
       return { where: { count } };
     },
     greaterThan(count) {
-      return { where: { count: { $gt: count } } };
+      return { where: { count: { [Op.gt]: count } } };
     },
     lessThan(count) {
-      return { where: { count: { $lt: count } } };
+      return { where: { count: { [Op.lt]: count } } };
     },
     between(range) {
       const dates = moment.range(range);
       return {
         where: {
           createdAt: {
-            $between: [dates.start.toDate(), dates.end.toDate()],
+            [Op.between]: [dates.start.toDate(), dates.end.toDate()],
           },
         },
       };
@@ -42,7 +42,7 @@ export default sequelize.define('headcounts', {
       return {
         where: {
           createdAt: {
-            $between: [start, end],
+            [Op.between]: [start, end],
           },
         },
       };

--- a/models/membership.js
+++ b/models/membership.js
@@ -1,4 +1,4 @@
-import DataTypes from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import sequelize from '../config/sequelize';
@@ -57,7 +57,7 @@ export default sequelize.define('memberships', {
       return {
         where: {
           startDate: {
-            $between: [dates.start.toDate(), dates.end.toDate()],
+            [Op.between]: [dates.start.toDate(), dates.end.toDate()],
           },
         },
       };
@@ -66,10 +66,10 @@ export default sequelize.define('memberships', {
       return {
         where: {
           startDate: {
-            $lte: date,
+            [Op.lte]: date,
           },
           endDate: {
-            $gte: date,
+            [Op.gte]: date,
           },
         },
       };

--- a/models/mentor.js
+++ b/models/mentor.js
@@ -1,4 +1,4 @@
-import DataTypes from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
 import Specialty from './specialty';
@@ -22,12 +22,12 @@ export default sequelize.define('mentors', {
       return {
         where: {
           startDate: {
-            $lte: date,
+            [Op.lte]: date,
           },
           endDate: {
-            $or: {
-              $gte: date,
-              $eq: null,
+            [Op.or]: {
+              [Op.gte]: date,
+              [Op.eq]: null,
             },
           },
         },

--- a/models/officer.js
+++ b/models/officer.js
@@ -1,4 +1,4 @@
-import DataTypes from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
 import sorting from '../helpers/sorting';
@@ -58,12 +58,12 @@ export default sequelize.define('officers', {
       return {
         where: {
           startDate: {
-            $lte: date,
+            [Op.lte]: date,
           },
           endDate: {
-            $or: {
-              $gte: date,
-              $eq: null,
+            [Op.or]: {
+              [Op.gte]: date,
+              [Op.eq]: null,
             },
           },
         },

--- a/models/quote.js
+++ b/models/quote.js
@@ -1,4 +1,4 @@
-import DataTypes from 'sequelize';
+import { DataTypes, Op } from 'sequelize';
 import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
 import sorting from '../helpers/sorting';
@@ -54,12 +54,12 @@ export default sequelize.define('quotes', {
     search(query) {
       return {
         where: {
-          $or: {
+          [Op.or]: {
             body: {
-              $like: `%${query}%`,
+              [Op.like]: `%${query}%`,
             },
             description: {
-              $like: `%${query}%`,
+              [Op.like]: `%${query}%`,
             },
           },
         },

--- a/models/user.js
+++ b/models/user.js
@@ -4,8 +4,6 @@ import sequelize from '../config/sequelize';
 import paginate from '../helpers/paginate';
 import sorting from '../helpers/sorting';
 import nconf from '../config';
-import Officers from './officer';
-import Mentors from './mentor';
 
 const Users = sequelize.define('users', {
   firstName: DataTypes.STRING,
@@ -47,31 +45,29 @@ const Users = sequelize.define('users', {
   },
 });
 
-Users.prototype.currentGroups = () => Promise.all([
-  Officers.scope(
-    { method: ['active', new Date()] }
-  ).findAll(),
-  Mentors.scope(
-    { method: ['active', new Date()] }
-  ).findAll(),
-])
-  .spread((officers, mentors) => {
-    const groups = [];
-    if (officers.length > 0) {
-      groups.push('officers');
-      if (officers[0].primaryOfficer) {
-        groups.push('primary');
+Users.prototype.currentGroups = function () {
+  return Promise.all([
+    this.getOfficers({ scope: { method: ['active', new Date()] } }),
+    this.getMentors({ scope: { method: ['active', new Date()] } }),
+  ])
+    .spread((officers, mentors) => {
+      const groups = [];
+      if (officers.length > 0) {
+        groups.push('officers');
+        if (officers[0].primaryOfficer) {
+          groups.push('primary');
+        }
       }
-    }
-    if (mentors.length > 0) {
-      groups.push('mentors');
-    }
-    return groups;
-  });
+      if (mentors.length > 0) {
+        groups.push('mentors');
+      }
+      return groups;
+    });
+};
 
-Users.prototype.can = (endpoint, action, level) => {
+Users.prototype.can = function (endpoint, action, level) {
   const permission = nconf.get('permissions')[endpoint][action];
-  return Users.prototype
+  return this
     .currentGroups()
     .filter(group => permission.groups[group] && level >= permission.level)
     .then((p) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,9 +1762,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-writer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
-      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -4407,11 +4407,6 @@
         "is-property": "^1.0.0"
       }
     },
-    "generic-pool": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz",
-      "integrity": "sha1-iGvFvwvrfblugby7oHiBjeWmJoM="
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -5969,11 +5964,6 @@
           }
         }
       }
-    },
-    "js-string-escape": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -8613,9 +8603,9 @@
       }
     },
     "packet-reader": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
-      "integrity": "sha1-gZ300BC4LV6lZx+KGjrPA5vNdwA="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -8736,18 +8726,25 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.7.tgz",
-      "integrity": "sha1-Ra4WsjcGpjRaAyed7MaveVwW0ps=",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.2.tgz",
+      "integrity": "sha512-Mvt0dGYMwvEADNKy5PMQGlzPudKcKKzJds/VbOeZJpb6f/pI3mmoXX0JksPgI3l3JPP/2Apq7F36O63J7mgveA==",
       "requires": {
-        "buffer-writer": "1.0.1",
-        "generic-pool": "2.4.2",
-        "js-string-escape": "1.0.1",
-        "packet-reader": "0.2.0",
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-types": "1.*",
-        "pgpass": "0.0.3",
-        "semver": "^4.1.0"
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.10",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        }
       }
     },
     "pg-connection-string": {
@@ -8768,24 +8765,34 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+    },
+    "pg-pool": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
+    },
     "pg-types": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
-      "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "requires": {
         "pg-int8": "1.0.1",
-        "postgres-array": "~1.0.0",
+        "postgres-array": "~2.0.0",
         "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.0",
+        "postgres-date": "~1.0.4",
         "postgres-interval": "^1.1.0"
       }
     },
     "pgpass": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
-      "integrity": "sha1-EuZ+NDsxicLzEgbrycwL7//PkUA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
       "requires": {
-        "split": "~0.3"
+        "split": "^1.0.0"
       }
     },
     "pify": {
@@ -9676,9 +9683,9 @@
       "dev": true
     },
     "postgres-array": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
-      "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
     "postgres-bytea": {
       "version": "1.0.0",
@@ -9686,14 +9693,14 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
-      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
     },
     "postgres-interval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
-      "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -10410,7 +10417,8 @@
     "semver": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -11132,9 +11140,9 @@
       "dev": true
     },
     "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
         "through": "2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -341,8 +341,7 @@
     "@types/node": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.0.tgz",
-      "integrity": "sha512-zkYho6/4wZyX6o9UQ8rd0ReEaiEYNNCqYFIAACe2Tf9DrYlgzWW27OigYHnnztnnZQwVRpwWmZKegFmDpinIsA==",
-      "dev": true
+      "integrity": "sha512-zkYho6/4wZyX6o9UQ8rd0ReEaiEYNNCqYFIAACe2Tf9DrYlgzWW27OigYHnnztnnZQwVRpwWmZKegFmDpinIsA=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -2067,6 +2066,15 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "cls-bluebird": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
+      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
+      "requires": {
+        "is-bluebird": "^1.0.2",
+        "shimmer": "^1.1.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2773,9 +2781,9 @@
       }
     },
     "dottie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-1.1.1.tgz",
-      "integrity": "sha1-RcKj9IvWUo7u0memmoSOqspvqmo="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
+      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -5450,6 +5458,11 @@
       "requires": {
         "binary-extensions": "^1.0.0"
       }
+    },
+    "is-bluebird": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -10322,13 +10335,6 @@
       "requires": {
         "bluebird": "^3.4.6",
         "debug": "^2.6.9"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-        }
       }
     },
     "rgb-hex": {
@@ -10457,55 +10463,56 @@
       }
     },
     "sequelize": {
-      "version": "3.31.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-3.31.1.tgz",
-      "integrity": "sha512-fRb2cu3d+A7wwBuHmfe+SP5nhkQ9pDS3nR/KBmjRK0EpBYRJmNggOqfEShuBgX+QztjXLFiemnT0AtjykfVUGw==",
+      "version": "4.44.4",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.44.4.tgz",
+      "integrity": "sha512-nkHmYkbwQK7uwpgW9VBalCBnQqQ8mslTdgcBthtJLORuPvAYRPlfkXZMVUU9TLLJt9CX+/y0MYg0DpcP6ywsEQ==",
       "requires": {
-        "bluebird": "^3.3.4",
+        "bluebird": "^3.5.0",
+        "cls-bluebird": "^2.1.0",
+        "debug": "^3.1.0",
         "depd": "^1.1.0",
-        "dottie": "^1.0.0",
-        "generic-pool": "2.4.2",
-        "inflection": "^1.6.0",
-        "lodash": "4.12.0",
-        "moment": "^2.13.0",
-        "moment-timezone": "^0.5.4",
-        "retry-as-promised": "^2.0.0",
-        "semver": "^5.0.1",
-        "shimmer": "1.1.0",
-        "terraformer-wkt-parser": "^1.1.0",
+        "dottie": "^2.0.0",
+        "generic-pool": "3.5.0",
+        "inflection": "1.12.0",
+        "lodash": "^4.17.1",
+        "moment": "^2.20.0",
+        "moment-timezone": "^0.5.14",
+        "retry-as-promised": "^2.3.2",
+        "semver": "^5.5.0",
+        "terraformer-wkt-parser": "^1.1.2",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.0.0",
-        "validator": "^5.2.0",
-        "wkx": "0.2.0"
+        "uuid": "^3.2.1",
+        "validator": "^10.4.0",
+        "wkx": "^0.4.1"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-        },
-        "lodash": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
-          "integrity": "sha1-K9bcRqBA9Z5obJcu0h2T3FkFMlg="
-        },
-        "moment-timezone": {
-          "version": "0.5.14",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
-          "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "moment": ">= 2.9.0"
+            "ms": "^2.1.1"
           }
         },
+        "generic-pool": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.5.0.tgz",
+          "integrity": "sha512-dEkxmX+egB2o4NR80c/q+xzLLzLX+k68/K8xv81XprD+Sk7ZtP14VugeCz+fUwv5FzpWq40pPtAkzPRqT8ka9w=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -10876,9 +10883,9 @@
       }
     },
     "shimmer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
-      "integrity": "sha1-l9c3cTf/u6tCVSLkKf4KqJpIizU="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "sigmund": {
       "version": "1.0.1",
@@ -11679,18 +11686,19 @@
       }
     },
     "terraformer": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
-      "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.10.tgz",
+      "integrity": "sha512-5c6cAfKTZHAeRdT8sIRRidhN1w+vsmf3RmQn+PKksFhTUnsBtjQdbJG2vaxM6T47IU2EeR1S8t8UjTYY9Q1yJA==",
       "requires": {
-        "@types/geojson": "^1.0.0"
+        "@types/geojson": "^7946.0.0 || ^1.0.0"
       }
     },
     "terraformer-wkt-parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
-      "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.1.tgz",
+      "integrity": "sha512-+CJyNLWb3lJ9RsZMTM66BY0MT3yIo4l4l22Jd9CrZuwzk54fsu4Sc7zejuS9fCITTuTQy3p06d4MZMVI7v5wSg==",
       "requires": {
+        "@types/geojson": "^1.0.0",
         "terraformer": "~1.0.5"
       }
     },
@@ -12322,9 +12330,9 @@
       }
     },
     "validator": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-5.7.0.tgz",
-      "integrity": "sha1-eoelgUa2laxIYHEUHAxJ1n2gXlw="
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -12617,9 +12625,12 @@
       "integrity": "sha1-oJYpuakgAo1yFAT7Q1vc/1yRvCE="
     },
     "wkx": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.2.0.tgz",
-      "integrity": "sha1-dsJPFqzQzY+TzTSqMx4PeWElboQ="
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
+      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,11 +333,6 @@
         "lodash": "^4.17.4"
       }
     },
-    "@types/geojson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
-      "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
-    },
     "@types/node": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.0.tgz",
@@ -474,6 +469,11 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "anymatch": {
       "version": "1.3.2",
@@ -10329,12 +10329,11 @@
       "dev": true
     },
     "retry-as-promised": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.2.tgz",
-      "integrity": "sha1-zZdO5P2bX+A8vzGHHuSCIcB3N7c=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
+      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
       "requires": {
-        "bluebird": "^3.4.6",
-        "debug": "^2.6.9"
+        "any-promise": "^1.3.0"
       }
     },
     "rgb-hex": {
@@ -10463,41 +10462,47 @@
       }
     },
     "sequelize": {
-      "version": "4.44.4",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.44.4.tgz",
-      "integrity": "sha512-nkHmYkbwQK7uwpgW9VBalCBnQqQ8mslTdgcBthtJLORuPvAYRPlfkXZMVUU9TLLJt9CX+/y0MYg0DpcP6ywsEQ==",
+      "version": "5.21.5",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.5.tgz",
+      "integrity": "sha512-n9hR5K4uQGmBGK/Y/iqewCeSFmKVsd0TRnh0tfoLoAkmXbKC4tpeK96RhKs7d+TTMtrJlgt2TNLVBaAxEwC4iw==",
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",
-        "debug": "^3.1.0",
-        "depd": "^1.1.0",
+        "debug": "^4.1.1",
         "dottie": "^2.0.0",
-        "generic-pool": "3.5.0",
         "inflection": "1.12.0",
-        "lodash": "^4.17.1",
-        "moment": "^2.20.0",
-        "moment-timezone": "^0.5.14",
-        "retry-as-promised": "^2.3.2",
-        "semver": "^5.5.0",
-        "terraformer-wkt-parser": "^1.1.2",
+        "lodash": "^4.17.15",
+        "moment": "^2.24.0",
+        "moment-timezone": "^0.5.21",
+        "retry-as-promised": "^3.2.0",
+        "semver": "^6.3.0",
+        "sequelize-pool": "^2.3.0",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.2.1",
-        "validator": "^10.4.0",
-        "wkx": "^0.4.1"
+        "uuid": "^3.3.3",
+        "validator": "^10.11.0",
+        "wkx": "^0.4.8"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
-        "generic-pool": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.5.0.tgz",
-          "integrity": "sha512-dEkxmX+egB2o4NR80c/q+xzLLzLX+k68/K8xv81XprD+Sk7ZtP14VugeCz+fUwv5FzpWq40pPtAkzPRqT8ka9w=="
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "moment-timezone": {
+          "version": "0.5.28",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+          "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+          "requires": {
+            "moment": ">= 2.9.0"
+          }
         },
         "ms": {
           "version": "2.1.2",
@@ -10505,9 +10510,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "uuid": {
           "version": "3.4.0",
@@ -10805,6 +10810,11 @@
           }
         }
       }
+    },
+    "sequelize-pool": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
+      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
     },
     "serve-static": {
       "version": "1.13.1",
@@ -11683,23 +11693,6 @@
       "dev": true,
       "requires": {
         "execa": "^0.7.0"
-      }
-    },
-    "terraformer": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.10.tgz",
-      "integrity": "sha512-5c6cAfKTZHAeRdT8sIRRidhN1w+vsmf3RmQn+PKksFhTUnsBtjQdbJG2vaxM6T47IU2EeR1S8t8UjTYY9Q1yJA==",
-      "requires": {
-        "@types/geojson": "^7946.0.0 || ^1.0.0"
-      }
-    },
-    "terraformer-wkt-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.2.1.tgz",
-      "integrity": "sha512-+CJyNLWb3lJ9RsZMTM66BY0MT3yIo4l4l22Jd9CrZuwzk54fsu4Sc7zejuS9fCITTuTQy3p06d4MZMVI7v5wSg==",
-      "requires": {
-        "@types/geojson": "^1.0.0",
-        "terraformer": "~1.0.5"
       }
     },
     "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nodemailer-mailgun-transport": "^1.4.0",
     "pg": "^7.0.0",
     "pg-hstore": "^2.3.2",
-    "sequelize": "^5.0.0",
+    "sequelize": "^5.21.5",
     "sqlite3": "^4.0.6",
     "umzug": "^1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nodemailer-mailgun-transport": "^1.4.0",
     "pg": "^4.4.1",
     "pg-hstore": "^2.3.2",
-    "sequelize": "^4.0.0",
+    "sequelize": "^5.0.0",
     "sqlite3": "^4.0.6",
     "umzug": "^1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "nconf": "^0.10.0",
     "nodemailer": "^6.1.1",
     "nodemailer-mailgun-transport": "^1.4.0",
-    "pg": "^4.4.1",
+    "pg": "^7.0.0",
     "pg-hstore": "^2.3.2",
     "sequelize": "^5.0.0",
     "sqlite3": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nodemailer-mailgun-transport": "^1.4.0",
     "pg": "^4.4.1",
     "pg-hstore": "^2.3.2",
-    "sequelize": "^3.19.0",
+    "sequelize": "^4.0.0",
     "sqlite3": "^4.0.6",
     "umzug": "^1.6.0"
   },

--- a/routes/committees.js
+++ b/routes/committees.js
@@ -34,7 +34,7 @@ router
   .route('/:id')
     .get((req, res, next) => {
       Committee
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((committee) => {
           if (committee) {
             return res.send(committee);

--- a/routes/events.js
+++ b/routes/events.js
@@ -47,7 +47,7 @@ router
   .route('/:id')
     .get((req, res, next) => {
       Event
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((event) => {
           if (event) {
             return res.send(event);
@@ -58,7 +58,7 @@ router
     })
     .put(needs('events', 'update'), (req, res, next) => {
       Event
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((event) => {
           if (event) {
             return event.updateAttributes(req.body, {
@@ -72,7 +72,7 @@ router
     })
     .delete(needs('events', 'destroy'), (req, res, next) => {
       Event
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((event) => {
           if (event) {
             return event.destroy();

--- a/routes/events.js
+++ b/routes/events.js
@@ -61,7 +61,7 @@ router
         .findByPk(req.params.id)
         .then((event) => {
           if (event) {
-            return event.updateAttributes(req.body, {
+            return event.update(req.body, {
               fields: ['name', 'startDate', 'endDate', 'description', 'location', 'image', 'committeeName'],
             });
           }

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -49,7 +49,7 @@ router
         .findByPk(req.params.id)
         .then((headcount) => {
           if (headcount) {
-            return headcount.updateAttributes(req.body, {
+            return headcount.update(req.body, {
               fields: ['count'],
             });
           }

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -35,7 +35,7 @@ router
   .route('/:id')
     .get((req, res, next) => {
       Headcount
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((headcount) => {
           if (headcount) {
             return res.send(headcount);
@@ -46,7 +46,7 @@ router
     })
     .put(needs('headcounts', 'update'), (req, res, next) => {
       Headcount
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((headcount) => {
           if (headcount) {
             return headcount.updateAttributes(req.body, {
@@ -60,7 +60,7 @@ router
     })
     .delete(needs('headcounts', 'destroy'), (req, res, next) => {
       Headcount
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((headcount) => {
           if (headcount) {
             return headcount.destroy();

--- a/routes/links.js
+++ b/routes/links.js
@@ -44,7 +44,7 @@ router
   .route('/go/:shortLink')
     .get((req, res, next) => {
       Link
-        .findById(req.params.shortLink.toLocaleLowerCase())
+        .findByPk(req.params.shortLink.toLocaleLowerCase())
         .then((link) => {
           if (link) {
             return res.redirect(link.longLink);
@@ -58,7 +58,7 @@ router
   .route('/:shortLink')
     .get((req, res, next) => {
       Link
-        .findById(req.params.shortLink.toLocaleLowerCase())
+        .findByPk(req.params.shortLink.toLocaleLowerCase())
         .then((link) => {
           if (link) {
             return res.send(link);
@@ -69,7 +69,7 @@ router
     })
     .put(needs('links', 'update'), (req, res, next) => {
       Link
-        .findById(req.params.shortLink.toLocaleLowerCase())
+        .findByPk(req.params.shortLink.toLocaleLowerCase())
         .then((link) => {
           if (link) {
             return link.updateAttributes(req.body, {
@@ -83,7 +83,7 @@ router
     })
     .delete(needs('links', 'destroy'), (req, res, next) => {
       Link
-        .findById(req.params.shortLink.toLocaleLowerCase())
+        .findByPk(req.params.shortLink.toLocaleLowerCase())
         .then((link) => {
           if (link) {
             return link.destroy();

--- a/routes/links.js
+++ b/routes/links.js
@@ -13,7 +13,7 @@ router
       const scopes = scopify(req.query, 'onlyPublic');
       Link.scope(scopes)
         .findAndCountAll({
-          order: '"createdAt" DESC',
+          order: [['createdAt', 'DESC']],
         })
         .then(result => res.send({
           total: result.count,
@@ -72,7 +72,7 @@ router
         .findByPk(req.params.shortLink.toLocaleLowerCase())
         .then((link) => {
           if (link) {
-            return link.updateAttributes(req.body, {
+            return link.update(req.body, {
               fields: ['shortLink', 'longLink', 'description', 'public'],
             });
           }

--- a/routes/memberships.js
+++ b/routes/memberships.js
@@ -62,7 +62,7 @@ router
   .route('/:id')
   .get(verifyUser, needsApprovedOne('memberships'), (req, res, next) => {
     Membership
-      .findById(req.params.id, {
+      .findByPk(req.params.id, {
         include: [User],
       })
       .then((membership) => {
@@ -81,7 +81,7 @@ router
   })
   .put(needs('memberships', 'update'), (req, res, next) => {
     Membership
-      .findById(req.params.id)
+      .findByPk(req.params.id)
       .then((membership) => {
         if (membership) {
           return membership.updateAttributes(req.body, {
@@ -96,7 +96,7 @@ router
   })
   .delete(needs('memberships', 'destroy'), (req, res, next) => {
     Membership
-      .findById(req.params.id)
+      .findByPk(req.params.id)
       .then((membership) => {
         if (membership) {
           return membership.destroy();

--- a/routes/memberships.js
+++ b/routes/memberships.js
@@ -24,7 +24,7 @@ router
             [sequelize.fn('count', sequelize.col('userDce')), 'memberships'],
           ],
           group: ['userDce'],
-          order: 'memberships DESC',
+          order: [['memberships', 'DESC']],
         })
         .then(scoreboard => res.send(scoreboard))
         .catch(err => next(err));
@@ -84,7 +84,7 @@ router
       .findByPk(req.params.id)
       .then((membership) => {
         if (membership) {
-          return membership.updateAttributes(req.body, {
+          return membership.update(req.body, {
             fields: ['reason', 'approved', 'committeeName', 'userDce', 'startDate', 'endDate'],
           });
         }

--- a/routes/mentors.js
+++ b/routes/mentors.js
@@ -53,7 +53,7 @@ router
   .route('/:id')
   .get((req, res, next) => {
     Mentor
-      .findById(req.params.id, {
+      .findByPk(req.params.id, {
         include: [Specialty, User],
       })
       .then((mentor) => {
@@ -66,7 +66,7 @@ router
   })
   .put(needs('mentors', 'update'), (req, res, next) => {
     Mentor
-      .findById(req.params.id)
+      .findByPk(req.params.id)
       .then((mentor) => {
         if (mentor) {
           return mentor.updateAttributes(req.body, {
@@ -89,7 +89,7 @@ router
   })
   .delete(needs('mentors', 'destroy'), (req, res, next) => {
     Mentor
-      .findById(req.params.id)
+      .findByPk(req.params.id)
       .then((mentor) => {
         if (mentor) {
           return mentor.setSpecialties([]).then(() => mentor.destroy());

--- a/routes/mentors.js
+++ b/routes/mentors.js
@@ -69,7 +69,7 @@ router
       .findByPk(req.params.id)
       .then((mentor) => {
         if (mentor) {
-          return mentor.updateAttributes(req.body, {
+          return mentor.update(req.body, {
             fields: ['bio', 'userDce', 'startDate', 'endDate'],
           });
         }

--- a/routes/officers.js
+++ b/routes/officers.js
@@ -72,7 +72,7 @@ router
         .findByPk(req.params.id)
         .then((officer) => {
           if (officer) {
-            return officer.updateAttributes(req.body, {
+            return officer.update(req.body, {
               fields: ['title', 'email', 'userDce', 'committeeName', 'primaryOfficer', 'startDate', 'endDate'],
             });
           }

--- a/routes/officers.js
+++ b/routes/officers.js
@@ -56,7 +56,7 @@ router
   .route('/:id')
     .get((req, res, next) => {
       Officer
-        .findById(req.params.id, {
+        .findByPk(req.params.id, {
           include: [User],
         })
         .then((officer) => {
@@ -69,7 +69,7 @@ router
     })
     .put(needs('officers', 'update'), (req, res, next) => {
       Officer
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((officer) => {
           if (officer) {
             return officer.updateAttributes(req.body, {
@@ -84,7 +84,7 @@ router
     })
     .delete(needs('officers', 'destroy'), (req, res, next) => {
       Officer
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((officer) => {
           if (officer) {
             return officer.destroy();

--- a/routes/quotes.js
+++ b/routes/quotes.js
@@ -81,7 +81,7 @@ router
         })
         .then((quote) => {
           if (quote) {
-            return quote.updateAttributes(req.body, {
+            return quote.update(req.body, {
               fields: ['body', 'description', 'approved'],
             });
           }

--- a/routes/quotes.js
+++ b/routes/quotes.js
@@ -56,7 +56,7 @@ router
   .route('/:id')
     .get(verifyUser, needsApprovedOne('quotes'), (req, res, next) => {
       Quote
-        .findById(req.params.id, {
+        .findByPk(req.params.id, {
           include: [Tag],
         })
         .then((quote) => {
@@ -76,7 +76,7 @@ router
     .put(needs('quotes', 'update'), (req, res, next) => {
       req.body.tags = req.body.tags || [];
       Quote
-        .findById(req.params.id, {
+        .findByPk(req.params.id, {
           include: [Tag],
         })
         .then((quote) => {
@@ -106,7 +106,7 @@ router
     })
     .delete(needs('quotes', 'destroy'), (req, res, next) => {
       Quote
-        .findById(req.params.id)
+        .findByPk(req.params.id)
         .then((quote) => {
           if (quote) {
             return quote.destroy();

--- a/routes/tags.js
+++ b/routes/tags.js
@@ -18,16 +18,20 @@ router
       Tag
         .scope(scopes)
         .findAndCountAll()
-        .then(result => res.send({
-          total: result.count,
-          perPage: req.query.perPage,
-          currentPage: req.query.page,
-          data: result.rows.map((tag) => {
-            const t = tag.get({ plain: true });
-            Reflect.deleteProperty(t, 'quotes');
-            return t;
-          }),
-        }))
+        .then(result => {
+          const uniqueTags = {};
+          result.rows.forEach((tag) => {
+            const c = tag.get({ plain: true });
+            Reflect.deleteProperty(c, 'quotes');
+            uniqueTags[c.name] = c;
+          });
+          return res.send({
+            total: Object.keys(uniqueTags).length,
+            perPage: req.query.perPage,
+            currentPage: req.query.page,
+            data: Object.values(uniqueTags),
+          });
+        })
         .catch(err => next(err));
     });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -27,7 +27,7 @@ router
   .route('/:dce')
     .get((req, res, next) => {
       User
-        .findById(req.params.dce)
+        .findByPk(req.params.dce)
         .then((user) => {
           if (user) {
             return res.send(user);

--- a/test/routes/events.js
+++ b/test/routes/events.js
@@ -604,7 +604,7 @@ END:VCALENDAR`;
 
     it('Errors When Insufficient Fields Provided', function () {
       const expected = {
-        error: 'notNull Violation: name cannot be null,\nnotNull Violation: startDate cannot be null,\nnotNull Violation: endDate cannot be null,\nnotNull Violation: location cannot be null',
+        error: 'notNull Violation: events.name cannot be null,\nnotNull Violation: events.startDate cannot be null,\nnotNull Violation: events.endDate cannot be null,\nnotNull Violation: events.location cannot be null',
       };
 
       return request(app)

--- a/test/routes/memberships.js
+++ b/test/routes/memberships.js
@@ -510,7 +510,7 @@ describe('INTEGRATION TESTS: MEMBERSHIPS', function () {
 
     it('Errors When Insufficient Fields Provided', function () {
       const expected = {
-        error: 'notNull Violation: reason cannot be null',
+        error: 'notNull Violation: memberships.reason cannot be null',
       };
 
       return request(app)

--- a/test/routes/officers.js
+++ b/test/routes/officers.js
@@ -488,7 +488,7 @@ describe('INTEGRATION TESTS: OFFICERS', function () {
 
     it('Errors When Insufficient Fields Provided', function () {
       const expected = {
-        error: 'notNull Violation: title cannot be null,\nnotNull Violation: email cannot be null',
+        error: 'notNull Violation: officers.title cannot be null,\nnotNull Violation: officers.email cannot be null',
       };
 
       return request(app)

--- a/test/routes/quotes.js
+++ b/test/routes/quotes.js
@@ -122,7 +122,7 @@ describe('INTEGRATION TESTS: QUOTES', function () {
 
     it('Errors When Insufficient Fields Provided', function () {
       const expected = {
-        error: 'notNull Violation: body cannot be null',
+        error: 'notNull Violation: quotes.body cannot be null',
       };
 
       return request(app)


### PR DESCRIPTION
Updates to following package(s) (fixing vulnerabilities):
sequelize `^3.19.0` -> `^5.21.5`
pg `^4.4.1` -> `^7.0.0`

There are breaking changes between v3 and v4: https://sequelize.org/v4/manual/tutorial/upgrade-to-v4.html

    Sequelize models are now ES6 classes, so instanceMethods have been moved out of options. They are now set via prototype
    options.order now only allows arrays / sequelize methods, not string values
    `afterUpdate` is now within the hooks options, and not a direct prototype of a model

And breaking changes between v4 and v5: https://sequelize.org/master/manual/upgrade-to-v5.html

    Operator aliases are no longer allowed by default (`$lt` must now be `[Op.lt]`)
    `findById` is now `findByPk`
    `updateAttributes` is now `update`

The instance methods on sequelize models must use the classic function syntax over arrow function syntax, since arrow functions (`=>`) will lexically bind `this` to `undefined` based on the scope, whereas `function` will dynamically bind `this`.

The mocha tests began failing on upgrading to v5, as the version of pg we were using was too outdated for sequelize v5, so that has been updated as well.