### PR TITLE
Add announcements

### DIFF
--- a/config/permissions.js
+++ b/config/permissions.js
@@ -157,4 +157,18 @@ export default {
       groups: { primary, officers },
     },
   },
+  announcements: {
+    create: {
+      level: levels.high,
+      groups: { primary },
+    },
+    update: {
+      level: levels.high,
+      groups: { primary },
+    },
+    destroy: {
+      level: levels.high,
+      groups: { primary },
+    },
+  },
 };

--- a/db/migrations/20200328162403-create-announcement.js
+++ b/db/migrations/20200328162403-create-announcement.js
@@ -5,11 +5,11 @@ export function up(queryInterface, Sequelize) {
       primaryKey: true,
       autoIncrement: true,
     },
-    announcement: {
+    message: {
       type: Sequelize.TEXT,
       allowNull: false,
     },
-    announcementType: Sequelize.STRING,
+    category: Sequelize.STRING,
     active: {
       type: Sequelize.BOOLEAN,
       allowNull: false,

--- a/db/migrations/20200328162403-create-announcement.js
+++ b/db/migrations/20200328162403-create-announcement.js
@@ -1,0 +1,24 @@
+export function up(queryInterface, Sequelize) {
+  return queryInterface.createTable('announcements', {
+    id: {
+      type: Sequelize.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    announcement: {
+      type: Sequelize.TEXT,
+      allowNull: false,
+    },
+    announcementType: Sequelize.STRING,
+    active: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+    },
+    createdAt: Sequelize.DATE,
+    updatedAt: Sequelize.DATE,
+  });
+}
+
+export function down(queryInterface) {
+  return queryInterface.dropTable('announcements');
+}

--- a/models/announcement.js
+++ b/models/announcement.js
@@ -1,0 +1,33 @@
+import DataTypes from 'sequelize';
+import sequelize from '../config/sequelize';
+import paginate from '../helpers/paginate';
+import sorting from '../helpers/sorting';
+
+export default sequelize.define('announcements', {
+  announcement: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  announcementType: DataTypes.STRING,
+  active: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+  },
+}, {
+  scopes: {
+    onlyActive() {
+      return { where: { active: true } };
+    },
+    paginate,
+    orderBy(field, direction) {
+      return sorting(field, direction, [
+        'announcement',
+        'announcementType',
+        'active',
+        'createdAt',
+        'updatedAt',
+      ]);
+    },
+  },
+});
+

--- a/models/announcement.js
+++ b/models/announcement.js
@@ -4,11 +4,11 @@ import paginate from '../helpers/paginate';
 import sorting from '../helpers/sorting';
 
 export default sequelize.define('announcements', {
-  announcement: {
+  message: {
     type: DataTypes.STRING,
     allowNull: false,
   },
-  announcementType: DataTypes.STRING,
+  category: DataTypes.STRING,
   active: {
     type: DataTypes.BOOLEAN,
     allowNull: false,
@@ -21,8 +21,8 @@ export default sequelize.define('announcements', {
     paginate,
     orderBy(field, direction) {
       return sorting(field, direction, [
-        'announcement',
-        'announcementType',
+        'message',
+        'category',
         'active',
         'createdAt',
         'updatedAt',

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     {
       "name": "Bill Dybas",
       "email": "wmdybas@gmail.com"
+    },
+    {
+      "name": "Gavriel R-H",
+      "email": "gavriel@gavrielrh.com"
     }
   ],
   "main": "app.js",

--- a/routes/announcements.js
+++ b/routes/announcements.js
@@ -1,0 +1,79 @@
+import { Router } from 'express';
+import Announcement from '../models/announcement';
+import scopify from '../helpers/scopify';
+import { needs } from '../middleware/permissions';
+import sorting from '../middleware/sorting';
+import paginate from '../middleware/paginate';
+
+const router = Router(); // eslint-disable-line new-cap
+
+router
+  .route('/')
+  .get(paginate, sorting, (req, res, next) => {
+    const scopes = scopify(req.query, 'onlyActive');
+    Announcement.scope(scopes)
+      .findAndCountAll({
+        order: [['createdAt', 'DESC']],
+      })
+      .then(result => res.send({
+        total: result.count,
+        perPage: req.query.perPage,
+        currentPage: req.query.page,
+        data: result.rows,
+      }))
+      .catch(err => next(err));
+  })
+  .post(needs('announcements', 'create'), (req, res, next) => {
+    Announcement.create({
+      announcement: req.body.announcement,
+      announcementType: req.body.announcementType,
+      active: req.body.active,
+    }, { fields: ['announcement', 'announcementType', 'active'] })
+      .then(announcement => res.status(201).send(announcement))
+      .catch((err) => {
+        err.status = 422;
+        next(err);
+      });
+  });
+
+router
+  .route('/:id')
+  .get((req, res, next) => {
+    Announcement
+      .findByPk(req.params.id)
+      .then((announcement) => {
+        if (announcement) {
+          return res.send(announcement);
+        }
+        return Promise.reject({ message: 'Announcement not found', status: 404 });
+      })
+      .catch(err => next(err));
+  })
+  .put(needs('announcements', 'update'), (req, res, next) => {
+    Announcement
+      .findByPk(req.params.id)
+      .then((announcement) => {
+        if (announcement) {
+          return announcement.update(req.body, {
+            fields: ['announcement', 'announcementType', 'active'],
+          });
+        }
+        return Promise.reject({ message: 'Announcement not found', status: 404 });
+      })
+      .then(announcement => res.send(announcement))
+      .catch(err => next(err));
+  })
+  .delete(needs('announcements', 'destroy'), (req, res, next) => {
+    Announcement
+      .findByPk(req.params.id)
+      .then((announcement) => {
+        if (announcement) {
+          return announcement.destroy();
+        }
+        return Promise.reject({ message: 'Announcement not found', status: 404 });
+      })
+      .then(() => res.sendStatus(204))
+      .catch(err => next(err));
+  });
+
+export default router;

--- a/routes/announcements.js
+++ b/routes/announcements.js
@@ -25,10 +25,10 @@ router
   })
   .post(needs('announcements', 'create'), (req, res, next) => {
     Announcement.create({
-      announcement: req.body.announcement,
-      announcementType: req.body.announcementType,
+      message: req.body.message,
+      category: req.body.category,
       active: req.body.active,
-    }, { fields: ['announcement', 'announcementType', 'active'] })
+    }, { fields: ['message', 'category', 'active'] })
       .then(announcement => res.status(201).send(announcement))
       .catch((err) => {
         err.status = 422;
@@ -55,7 +55,7 @@ router
       .then((announcement) => {
         if (announcement) {
           return announcement.update(req.body, {
-            fields: ['announcement', 'announcementType', 'active'],
+            fields: ['message', 'category', 'active'],
           });
         }
         return Promise.reject({ message: 'Announcement not found', status: 404 });

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,6 +8,7 @@ import memberships from './memberships';
 import officers from './officers';
 import qdb from './qdb';
 import users from './users';
+import announcements from './announcements';
 import status from './status';
 import nconf from '../config';
 
@@ -35,6 +36,7 @@ router.use('/officers', officers);
 router.use('/qdb', qdb);
 router.use('/status', status);
 router.use('/users', users);
+router.use('/announcements', announcements);
 
 router
   .route('/')
@@ -49,6 +51,7 @@ router
     qdbUrl: `${apiPath}/qdb`,
     statusUrl: `${apiPath}/status`,
     usersUrl: `${apiPath}/users`,
+    announcementsUrl: `${apiPath}/announcements`,
   }));
 
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,6 +11,7 @@ import Officer from '../models/officer';
 import Quote from '../models/quote';
 import Tag from '../models/tag';
 import User from '../models/user';
+import Announcement from '../models/announcement';
 
 const jwtConfig = nconf.get('auth:jwt');
 
@@ -113,7 +114,7 @@ export function beforeEachHelper() {
   return sequelize
     .transaction(t => Promise.all(
         // Truncate all tables
-        [Event, Committee, User, Officer, Membership, Quote, Tag]
+        [Event, Committee, User, Officer, Membership, Quote, Tag, Announcement]
           .map(model => model.destroy({
             truncate: true,
             transaction: t,
@@ -320,5 +321,17 @@ export function beforeEachHelper() {
         quotes[1].setTags([tags[0]]),
         quotes[2].setTags([tags[0], tags[1]]),
         quotes[3].setTags([tags[0], tags[1], tags[2]]),
-      ]));
+      ]))
+    .then(() => Announcement.bulkCreate([
+      {
+        announcement: 'hello everyone!',
+        announcementType: 'warning',
+        active: false,
+      },
+      {
+        announcement: 'This is an announcement',
+        announcementType: 'primary',
+        active: true,
+      },
+    ]));
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -324,13 +324,13 @@ export function beforeEachHelper() {
       ]))
     .then(() => Announcement.bulkCreate([
       {
-        announcement: 'hello everyone!',
-        announcementType: 'warning',
+        message: 'hello everyone!',
+        category: 'warning',
         active: false,
       },
       {
-        announcement: 'This is an announcement',
-        announcementType: 'primary',
+        message: 'This is an announcement',
+        category: 'primary',
         active: true,
       },
     ]));

--- a/test/routes/announcements.js
+++ b/test/routes/announcements.js
@@ -1,0 +1,338 @@
+/* eslint-env mocha */
+/* eslint-disable func-names, prefer-arrow-callback  */
+
+import { expect } from 'chai';
+import request from 'supertest';
+
+import app from '../../app';
+import nconf from '../../config';
+import {
+  token,
+  lowPermissionPrimaryToken,
+  highPermissionOfficerToken,
+  lowPermissionOfficerToken,
+  highPermissionUserToken,
+} from '../helpers';
+
+describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
+  describe('GET /', function () {
+    it('Gets Active Announcements (In Descending Order)', function () {
+      const expected = {
+        total: 2,
+        perPage: nconf.get('pagination:perPage'),
+        currentPage: 1,
+        data: [
+          {
+            active: false,
+            announcement: 'hello everyone!',
+            announcementType: 'warning',
+          },
+          {
+            active: true,
+            announcement: 'This is an announcement',
+            announcementType: 'primary',
+          },
+        ],
+      };
+
+      return request(app)
+        .get('/api/v2/announcements')
+        .expect(200)
+        .then((response) => {
+          response.body.data.forEach((announcement) => {
+            delete announcement.id;
+            delete announcement.createdAt;
+            delete announcement.updatedAt;
+          });
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+  });
+
+  describe('POST /', function () {
+    it('Requires Authentication', function () {
+      const expected = {
+        error: 'No authorization token was found',
+      };
+
+      return request(app)
+        .post('/api/v2/announcements')
+        .expect(401)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+
+    it('Requires Expected Permissions', function () {
+      const expected = {
+        error: 'User does not have permission: create announcements',
+      };
+
+      const announcementInput = {
+        announcement: 'This is a test',
+        announcementType: 'warning',
+        active: true,
+      };
+
+      // Deny Primary Officer w/ Low Permission Token
+      const primaryLow = request(app)
+        .post('/api/v2/announcements')
+        .set('Authorization', `Bearer ${lowPermissionPrimaryToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Deny Officer w/ High Permission Token
+      const officerHigh = request(app)
+        .post('/api/v2/announcements')
+        .set('Authorization', `Bearer ${highPermissionOfficerToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Deny User w/ High Permission Token
+      const userHigh = request(app)
+        .post('/api/v2/announcements')
+        .set('Authorization', `Bearer ${highPermissionUserToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Allow Primary Officer w/ High Permission Token
+      const primaryHigh = request(app)
+        .post('/api/v2/announcements')
+        .set('Authorization', `Bearer ${token}`)
+        .send(announcementInput)
+        .expect(201);
+
+      return Promise.all([
+        primaryLow,
+        userHigh,
+        primaryHigh,
+        officerHigh,
+      ]);
+    });
+  });
+
+  describe('GET /:id', function () {
+    it('Gets a Specific Announcement', function () {
+      const expected = {
+        id: 2,
+        announcement: 'This is an announcement',
+        announcementType: 'primary',
+        active: true,
+      };
+
+      return request(app)
+        .get('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200)
+        .then((response) => {
+          delete response.body.createdAt;
+          delete response.body.updatedAt;
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+
+    it('Does Not Find a Non-existent Announcement', function () {
+      const expected = {
+        error: 'Announcement not found',
+      };
+
+      return request(app)
+        .get('/api/v2/announcements/100')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+  });
+
+  describe('PUT /:id', function () {
+    it('Requires Authentication', function () {
+      const expected = {
+        error: 'No authorization token was found',
+      };
+
+      return request(app)
+        .put('/api/v2/announcements/1')
+        .expect(401)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+
+    it('Requires Expected Permissions', function () {
+      // Need High Permissions be Primary Officer
+      const expected = {
+        error: 'User does not have permission: update announcements',
+      };
+
+      const announcementInput = {
+        announcementType: 'cool',
+      };
+
+      // Deny Primary Officer w/ Low Permission Token
+      const primaryLow = request(app)
+        .put('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${lowPermissionPrimaryToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Deny Officer w/ High Permission Token
+      const officerHigh = request(app)
+        .put('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${highPermissionOfficerToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Deny User w/ High Permission Token
+      const userHigh = request(app)
+        .put('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${highPermissionUserToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Allow Primary Officer w/ High Permission Token
+      const primaryHigh = request(app)
+        .put('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${token}`)
+        .send(announcementInput)
+        .expect(200);
+
+      return Promise.all([
+        primaryLow,
+        userHigh,
+        primaryHigh,
+        officerHigh,
+      ]);
+    });
+
+    it('Updates a Specific Announcement', function () {
+      const expected = {
+        id: 2,
+        announcement: 'You just got updated',
+        announcementType: 'potato',
+        active: true,
+      };
+
+      return request(app)
+        .put('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          announcement: 'You just got updated',
+          announcementType: 'potato',
+        })
+        .expect(200)
+        .then((response) => {
+          delete response.body.createdAt;
+          delete response.body.updatedAt;
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+
+    it('Does Not Find and Update a Non-existent Announcement', function () {
+      const expected = {
+        error: 'Announcement not found',
+      };
+
+      return request(app)
+        .put('/api/v2/announcements/100')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+  });
+
+  describe('DELETE /:id', function () {
+    it('Requires Authentication', function () {
+      const expected = {
+        error: 'No authorization token was found',
+      };
+
+      return request(app)
+        .delete('/api/v2/announcements/1')
+        .expect(401)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+
+    it('Requires Expected Permissions', function () {
+      // Need High Permissions be Primary Officer
+      const expected = {
+        error: 'User does not have permission: destroy announcements',
+      };
+
+      // Deny Primary Officer w/ Low Permission Token
+      const primaryLow = request(app)
+        .delete('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${lowPermissionPrimaryToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Deny Officer w/ High Permission Token
+      const officerHigh = request(app)
+        .delete('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${highPermissionOfficerToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Deny User w/ High Permission Token
+      const userHigh = request(app)
+        .delete('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${highPermissionUserToken}`)
+        .expect(403)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+      // Allow Primary Officer w/ High Permission Token
+      const primaryHigh = request(app)
+        .delete('/api/v2/announcements/2')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204);
+
+      return Promise.all([
+        primaryLow,
+        officerHigh,
+        userHigh,
+        primaryHigh,
+      ]);
+    });
+
+    it('Deletes a Specific Announcement', function () {
+      return request(app)
+        .delete('/api/v2/announcements/1')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(204)
+        .then(() => {
+          request(app)
+            .get('/api/v2/announcements/1')
+            .set('Authorization', `Bearer ${token}`)
+            .expect(404);
+        });
+    });
+
+    it('Does Not Find and Delete a Non-existent Announcement', function () {
+      const expected = {
+        error: 'Announcement not found',
+      };
+
+      return request(app)
+        .delete('/api/v2/announcements/100')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404)
+        .then((response) => {
+          expect(response.body).to.deep.equal(expected);
+        });
+    });
+  })
+});

--- a/test/routes/announcements.js
+++ b/test/routes/announcements.js
@@ -24,13 +24,13 @@ describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
         data: [
           {
             active: false,
-            announcement: 'hello everyone!',
-            announcementType: 'warning',
+            message: 'hello everyone!',
+            category: 'warning',
           },
           {
             active: true,
-            announcement: 'This is an announcement',
-            announcementType: 'primary',
+            message: 'This is an announcement',
+            category: 'primary',
           },
         ],
       };
@@ -69,8 +69,8 @@ describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
       };
 
       const announcementInput = {
-        announcement: 'This is a test',
-        announcementType: 'warning',
+        message: 'This is a test',
+        category: 'warning',
         active: true,
       };
 
@@ -118,8 +118,8 @@ describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
     it('Gets a Specific Announcement', function () {
       const expected = {
         id: 2,
-        announcement: 'This is an announcement',
-        announcementType: 'primary',
+        message: 'This is an announcement',
+        category: 'primary',
         active: true,
       };
 
@@ -170,7 +170,7 @@ describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
       };
 
       const announcementInput = {
-        announcementType: 'cool',
+        category: 'danger',
       };
 
       // Deny Primary Officer w/ Low Permission Token
@@ -215,8 +215,8 @@ describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
     it('Updates a Specific Announcement', function () {
       const expected = {
         id: 2,
-        announcement: 'You just got updated',
-        announcementType: 'potato',
+        message: 'You just got updated',
+        category: 'info',
         active: true,
       };
 
@@ -224,8 +224,8 @@ describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
         .put('/api/v2/announcements/2')
         .set('Authorization', `Bearer ${token}`)
         .send({
-          announcement: 'You just got updated',
-          announcementType: 'potato',
+          message: 'You just got updated',
+          category: 'info',
         })
         .expect(200)
         .then((response) => {
@@ -334,5 +334,5 @@ describe('INTEGRATION TESTS: ANNOUNCEMENTS', function () {
           expect(response.body).to.deep.equal(expected);
         });
     });
-  })
+  });
 });


### PR DESCRIPTION
The goal of this PR is to enable primary officers to make site-wide announcements via the API.
These announcements would likely be rendered via some sort of banner/notification at the top of a site.

Adds `announcements` as a new table (via migration and defined model), along with corresponding CRUD endpoints and integration tests.

Creating/Updating/Deleting announcements are restricted to primaries only.

Format of announcement:
```json
{
  "announcement": "i liek mudkipz",
  "announcementType": "warning",
  "active": true
}
```

I'm not at all attached to these parameters, and I'd be happy to rename them / add / remove params as appropriate.